### PR TITLE
fix banlist: java.lang.ArrayIndexOutOfBoundsException: 0

### DIFF
--- a/src/main/java/cn/nukkit/command/defaults/BanListCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/BanListCommand.java
@@ -36,8 +36,9 @@ public class BanListCommand extends VanillaCommand {
                 return false;
             }
         } else {
-            list = sender.getServer().getNameBans();
-            args[0] = "players";
+            sender.sendMessage(new TranslationContainer("commands.generic.usage", this.usageMessage));
+
+            return false;
         }
 
         String message = "";


### PR DESCRIPTION
fix banlist: java.lang.ArrayIndexOutOfBoundsException: 0