### PR TITLE
Fix some IDE can't compiling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>  
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>


### PR DESCRIPTION
Using 'UTF-8' encoding to copy filtered resources.