### PR TITLE
Fix NullPointerException in chunk generator

### DIFF
--- a/src/main/java/cn/nukkit/level/generator/task/PopulationTask.java
+++ b/src/main/java/cn/nukkit/level/generator/task/PopulationTask.java
@@ -1,7 +1,6 @@
 package cn.nukkit.level.generator.task;
 
 import cn.nukkit.Server;
-import cn.nukkit.level.ChunkManagerPool;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.SimpleChunkManager;
 import cn.nukkit.level.format.generic.BaseFullChunk;
@@ -37,103 +36,102 @@ public class PopulationTask extends AsyncTask {
 
     @Override
     public void onRun() {
-        SimpleChunkManager manager = (SimpleChunkManager) ChunkManagerPool.get(this.levelId);
-
         Generator generator = GeneratorPool.get(this.levelId);
 
-        if (manager == null || generator == null) {
+        if (generator == null) {
             this.state = false;
             return;
         }
 
-        synchronized (manager) {
-            synchronized (generator) {
-                synchronized (generator.getChunkManager()) {
-                    BaseFullChunk[] chunks = new BaseFullChunk[9];
+        SimpleChunkManager manager = (SimpleChunkManager) generator.getChunkManager();
 
-                    BaseFullChunk chunk = this.chunk.clone();
+        if (manager == null) {
+            this.state = false;
+            return;
+        }
 
-                    if (chunk == null) {
-                        return;
+        synchronized (generator.getChunkManager()) {
+            BaseFullChunk[] chunks = new BaseFullChunk[9];
+            BaseFullChunk   chunk  = this.chunk.clone();
+
+            if (chunk == null) {
+                return;
+            }
+
+            for (int i = 0; i < 9; i++) {
+                if (i == 4) {
+                    continue;
+                }
+
+                int xx = -1 + i % 3;
+                int zz = -1 + (i / 3);
+
+                BaseFullChunk ck = this.chunks[i];
+
+                if (ck == null) {
+                    try {
+                        chunks[i] = (BaseFullChunk) this.chunk.getClass().getMethod("getEmptyChunk", int.class, int.class).invoke(null, chunk.getX() + xx, chunk.getZ() + zz);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
                     }
+                } else {
+                    chunks[i] = ck.clone();
+                }
+            }
 
-                    for (int i = 0; i < 9; i++) {
-                        if (i == 4) {
-                            continue;
-                        }
+            manager.setChunk(chunk.getX(), chunk.getZ(), chunk);
+            if (!chunk.isGenerated()) {
+                generator.generateChunk(chunk.getX(), chunk.getZ());
+                chunk.setGenerated();
+            }
 
-                        int xx = -1 + i % 3;
-                        int zz = -1 + (i / 3);
-                        BaseFullChunk ck = this.chunks[i];
-
-                        if (ck == null) {
-                            try {
-                                chunks[i] = (BaseFullChunk) this.chunk.getClass().getMethod("getEmptyChunk", int.class, int.class).invoke(null, chunk.getX() + xx, chunk.getZ() + zz);
-                            } catch (Exception e) {
-                                throw new RuntimeException(e);
-                            }
-                        } else {
-                            chunks[i] = ck.clone();
-                        }
-                    }
-
-                    manager.setChunk(chunk.getX(), chunk.getZ(), chunk);
-                    if (!chunk.isGenerated()) {
-                        generator.generateChunk(chunk.getX(), chunk.getZ());
-                        chunk.setGenerated();
-                    }
-
-                    for (BaseFullChunk c : chunks) {
-                        if (c != null) {
-                            manager.setChunk(c.getX(), c.getZ(), c);
-                            if (!c.isGenerated()) {
-                                generator.generateChunk(c.getX(), c.getZ());
-                                c = manager.getChunk(c.getX(), c.getZ());
-                                c.setGenerated();
-                                manager.setChunk(c.getX(), c.getZ(), c);
-                            }
-                        }
-                    }
-
-                    generator.populateChunk(chunk.getX(), chunk.getZ());
-
-                    chunk = manager.getChunk(chunk.getX(), chunk.getZ());
-                    chunk.recalculateHeightMap();
-                    chunk.populateSkyLight();
-                    chunk.setLightPopulated();
-                    chunk.setPopulated();
-                    this.chunk = chunk.clone();
-
-                    manager.setChunk(chunk.getX(), chunk.getZ(), null);
-
-                    for (int i = 0; i < chunks.length; i++) {
-                        if (i == 4) {
-                            continue;
-                        }
-
-                        BaseFullChunk c = chunks[i];
-                        if (c != null) {
-                            c = chunks[i] = manager.getChunk(c.getX(), c.getZ());
-                            if (!c.hasChanged()) {
-                                chunks[i] = null;
-                            }
-                        }
-                    }
-
-                    manager.cleanChunks();
-
-                    for (int i = 0; i < 9; i++) {
-                        if (i == 4) {
-                            continue;
-                        }
-
-                        this.chunks[i] = chunks[i] != null ? chunks[i].clone() : null;
+            for (BaseFullChunk c : chunks) {
+                if (c != null) {
+                    manager.setChunk(c.getX(), c.getZ(), c);
+                    if (!c.isGenerated()) {
+                        generator.generateChunk(c.getX(), c.getZ());
+                        c = manager.getChunk(c.getX(), c.getZ());
+                        c.setGenerated();
+                        manager.setChunk(c.getX(), c.getZ(), c);
                     }
                 }
             }
+
+            generator.populateChunk(chunk.getX(), chunk.getZ());
+
+            chunk = manager.getChunk(chunk.getX(), chunk.getZ());
+            chunk.recalculateHeightMap();
+            chunk.populateSkyLight();
+            chunk.setLightPopulated();
+            chunk.setPopulated();
+            this.chunk = chunk.clone();
+
+            manager.setChunk(chunk.getX(), chunk.getZ(), null);
+
+            for (int i = 0; i < chunks.length; i++) {
+                if (i == 4) {
+                    continue;
+                }
+
+                BaseFullChunk c = chunks[i];
+                if (c != null) {
+                    c = chunks[i] = manager.getChunk(c.getX(), c.getZ());
+                    if (!c.hasChanged()) {
+                        chunks[i] = null;
+                    }
+                }
+            }
+
+            manager.cleanChunks();
+
+            for (int i = 0; i < 9; i++) {
+                if (i == 4) {
+                    continue;
+                }
+
+                this.chunks[i] = chunks[i] != null ? chunks[i].clone() : null;
+            }
         }
-
-
     }
 
     @Override


### PR DESCRIPTION
这是治标不治本。你去看看Level.registerGenerator是怎么搞的吧，几个线程不停的覆盖表里面的levelId这个key，我看了表示很囧。
既然表是以levelId作为唯一索引的，给每个Level注册N个Generator意义何在。
请谨慎使用多线程。请谨慎对待资源竞争。
每个Level的交给一个Gnerator处理，每个Generator交给一个线程处理。