### PR TITLE
Add ability to save resource to defined file

### DIFF
--- a/src/main/java/cn/nukkit/plugin/PluginBase.java
+++ b/src/main/java/cn/nukkit/plugin/PluginBase.java
@@ -184,6 +184,11 @@ abstract public class PluginBase implements Plugin {
 
     @Override
     public boolean saveResource(String filename, boolean replace) {
+        File out = new File(this.dataFolder, filename);
+        return this.saveResource(filename, replace, out);
+    }
+
+    public boolean saveResource(String filename, boolean replace, File out) {
         if (filename.trim().equals("")) {
             return false;
         }
@@ -197,7 +202,6 @@ abstract public class PluginBase implements Plugin {
             this.dataFolder.mkdirs();
         }
 
-        File out = new File(this.dataFolder, filename);
         if (out.exists() && !replace) {
             return false;
         }


### PR DESCRIPTION
If you trying to save resource file using method plugin.saveResource ("lang/russian.lng", false); you can save it only to "<PluginName>/lang/russian.lng". 
But I think we need ability to save resource to file located anywhere (without keeping file path and name).

For example:
File out = new File ("current-language.lng");
plugin.saveResource ("lang/russian.yml", false,out);