### PR TITLE
Remove level from level map upon closing.

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -352,6 +352,7 @@ public class Level implements ChunkManager, Metadatable {
         this.blockMetadata = null;
         this.blockCache.clear();
         this.temporalPosition = null;
+        this.server.getLevels().remove(this.levelId);
     }
 
     public void addSound(Sound sound) {


### PR DESCRIPTION
This change stops the constant spam of NPEs if a level is unloaded by a plugin. It also stops the NPE on shutdown.

Here's the error it used to spam:
```
2016-1-29 03:54:24 [ALERT] java.lang.NullPointerException
	at cn.nukkit.level.Level.getName(Level.java:2353)
	at cn.nukkit.Server.checkTickUpdates(Server.java:908)
	at cn.nukkit.Server.tick(Server.java:942)
	at cn.nukkit.Server.tickProcessor(Unknown Source)
	at cn.nukkit.Server.start(Unknown Source)
	at cn.nukkit.Server.<init>(Unknown Source)
	at cn.nukkit.Nukkit.main(Nukkit.java:52)
```