### PR TITLE
PlayerDeathEvent should be cancellable.

### DIFF
--- a/src/main/java/cn/nukkit/event/player/PlayerDeathEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerDeathEvent.java
@@ -1,12 +1,13 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.Player;
+import cn.nukkit.event.Cancellable;
 import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.TextContainer;
 import cn.nukkit.event.entity.EntityDeathEvent;
 import cn.nukkit.item.Item;
 
-public class PlayerDeathEvent extends EntityDeathEvent {
+public class PlayerDeathEvent extends EntityDeathEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     public static HandlerList getHandlers() {


### PR DESCRIPTION
There's no reason to not let PlayerDeathEvent be cancellable. Look at #682 for reference.

@Pub4Game Happy?