### PR TITLE
Fix bouncing items

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockBricksStone.java
+++ b/src/main/java/cn/nukkit/block/BlockBricksStone.java
@@ -51,29 +51,6 @@ public class BlockBricksStone extends BlockSolid {
     }
 
     @Override
-    protected AxisAlignedBB recalculateBoundingBox() {
-        if ((this.meta & 0x08) > 0) {
-            return new AxisAlignedBB(
-                    this.x,
-                    this.y + 0.5,
-                    this.z,
-                    this.x + 1,
-                    this.y + 1,
-                    this.z + 1
-            );
-        } else {
-            return new AxisAlignedBB(
-                    this.x,
-                    this.y,
-                    this.z,
-                    this.x + 1,
-                    this.y + 0.5,
-                    this.z + 1
-            );
-        }
-    }
-
-    @Override
     public int[][] getDrops(Item item) {
         if (item.isPickaxe() && item.getTier() >= ItemTool.TIER_WOODEN) {
             return new int[][]{new int[]{Item.STONE_BRICKS, this.meta & 0x03, 1}};

--- a/src/main/java/cn/nukkit/block/BlockEndPortalFrame.java
+++ b/src/main/java/cn/nukkit/block/BlockEndPortalFrame.java
@@ -6,7 +6,7 @@ import cn.nukkit.math.AxisAlignedBB;
 /**
  * Created by Pub4Game on 26.12.2015.
  */
-public class BlockEndPortalFrame extends BlockSolid {
+public class BlockEndPortalFrame extends BlockTransparent {
 
     public BlockEndPortalFrame() {
         this(0);

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -703,13 +703,13 @@ public abstract class Entity extends Location implements Metadatable {
         double diffY = y - j;
         double diffZ = z - k;
 
-        if (Block.solid[this.level.getBlockIdAt(i, j, k)]) {
-            boolean flag = !Block.solid[this.level.getBlockIdAt(i - 1, j, k)];
-            boolean flag1 = !Block.solid[this.level.getBlockIdAt(i + 1, j, k)];
-            boolean flag2 = !Block.solid[this.level.getBlockIdAt(i, j - 1, k)];
-            boolean flag3 = !Block.solid[this.level.getBlockIdAt(i, j + 1, k)];
-            boolean flag4 = !Block.solid[this.level.getBlockIdAt(i, j, k - 1)];
-            boolean flag5 = !Block.solid[this.level.getBlockIdAt(i, j, k + 1)];
+        if (!Block.transparent[this.level.getBlockIdAt(i, j, k)]) {
+            boolean flag = Block.transparent[this.level.getBlockIdAt(i - 1, j, k)];
+            boolean flag1 = Block.transparent[this.level.getBlockIdAt(i + 1, j, k)];
+            boolean flag2 = Block.transparent[this.level.getBlockIdAt(i, j - 1, k)];
+            boolean flag3 = Block.transparent[this.level.getBlockIdAt(i, j + 1, k)];
+            boolean flag4 = Block.transparent[this.level.getBlockIdAt(i, j, k - 1)];
+            boolean flag5 = Block.transparent[this.level.getBlockIdAt(i, j, k + 1)];
 
             int direction = -1;
             double limit = 9999;


### PR DESCRIPTION
Tested in singleplayer, dropped items do not pop out of transparent blocks. This fixes #715.