### PR TITLE
Fixed #480

### DIFF
--- a/src/main/java/cn/nukkit/level/generator/task/LightPopulationTask.java
+++ b/src/main/java/cn/nukkit/level/generator/task/LightPopulationTask.java
@@ -38,7 +38,7 @@ public class LightPopulationTask extends AsyncTask {
 		        	int biomeColor = Biome.getBiome(chunk.getBiomeId(x, z)).getColor();
 		        	chunk.setBiomeColor(x, z, (biomeColor >> 16), (biomeColor >> 8) & 0xff, (biomeColor & 0xff));
 		        }		        	
-			}
+		}
         }
 
         this.chunk = chunk.clone();

--- a/src/main/java/cn/nukkit/level/generator/task/LightPopulationTask.java
+++ b/src/main/java/cn/nukkit/level/generator/task/LightPopulationTask.java
@@ -3,6 +3,7 @@ package cn.nukkit.level.generator.task;
 import cn.nukkit.Server;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.format.generic.BaseFullChunk;
+import cn.nukkit.level.generator.biome.Biome;
 import cn.nukkit.scheduler.AsyncTask;
 
 /**
@@ -29,6 +30,16 @@ public class LightPopulationTask extends AsyncTask {
         chunk.recalculateHeightMap();
         chunk.populateSkyLight();
         chunk.setLightPopulated();
+
+        for(int x = 0; x < 16; ++ x){
+			for(int z = 0; z < 16; ++ z){
+		        int[] blockColor = chunk.getBiomeColor(x, z);
+		        if(blockColor[0] == 0 && blockColor[1] == 0){
+		        	int biomeColor = Biome.getBiome(chunk.getBiomeId(x, z)).getColor();
+		        	chunk.setBiomeColor(x, z, (biomeColor >> 16), (biomeColor >> 8) & 0xff, (biomeColor & 0xff));
+		        }		        	
+			}
+        }
 
         this.chunk = chunk.clone();
     }

--- a/src/main/java/cn/nukkit/level/generator/task/LightPopulationTask.java
+++ b/src/main/java/cn/nukkit/level/generator/task/LightPopulationTask.java
@@ -32,7 +32,7 @@ public class LightPopulationTask extends AsyncTask {
         chunk.setLightPopulated();
 
         for(int x = 0; x < 16; ++ x){
-			for(int z = 0; z < 16; ++ z){
+		for(int z = 0; z < 16; ++ z){
 		        int[] blockColor = chunk.getBiomeColor(x, z);
 		        if(blockColor[0] == 0 && blockColor[1] == 0){
 		        	int biomeColor = Biome.getBiome(chunk.getBiomeId(x, z)).getColor();


### PR DESCRIPTION
If chunk block biome color is produced in black.
(or chunk block biome doesn't have any color)
LightPopulationTask is will be fixed that biome color.