### PR TITLE
Removal of not needed code

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -329,7 +329,6 @@ public abstract class BlockLiquid extends BlockTransparent {
             }
 
             this.getLevel().setBlock(block, this.getBlock(newFlowDecay), true);
-            this.getLevel().scheduleUpdate(block, this.tickRate());
         }
     }
 


### PR DESCRIPTION
BlockLiquid.java at 331 and 203, its parameter updates is set as true, which results in updating block. Thus, scheduling update is duplicating code. Also, water flows normally even if the code is removed.