### PR TITLE
Fixed leveldb dependency and overriding server.properties on server stop.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,15 +34,9 @@
             <version>2.13</version>
         </dependency>
 		<dependency>
-			<!-- This dependency doesn't seem to be available in public maven repos.
-			     The jar file is included with the project under the lib dir.
-			     You need to manually install it in your local maven repo.  
-			     The command below should work if mvn is on your path and you are in the lib dir:
-			     mvn install:install-file -Dfile=leveldb.jar -DgroupId=com.tinfoiled.mcpe.leveldb -DartifactId=leveldb -Dversion=0.8 -Dpackaging=jar 
-			 -->
-            <groupId>com.tinfoiled.mcpe.leveldb</groupId>
+            <groupId>org.dellroad</groupId>
             <artifactId>leveldb</artifactId>
-            <version>0.8</version>
+            <version>0.8.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -429,8 +429,6 @@ public class Server {
             this.setDefaultLevel(this.getLevelByName(defaultName));
         }
 
-        this.properties.save(true);
-
         if (this.getDefaultLevel() == null) {
             this.getLogger().emergency(this.getLanguage().translateString("nukkit.level.defaultError"));
             this.forceShutdown();


### PR DESCRIPTION
I was setting up this project and there was 1 dependency missing so I found on maven updated working dependency and I modified pom.xml, compiled and it seems to work fine.