### PR TITLE
fix memory leak

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2232,7 +2232,7 @@ public class Level implements ChunkManager, Metadatable {
             this.players.remove(entity.getId());
             this.checkSleep();
         } else {
-            entity.kill();
+            entity.close();
         }
 
         this.entities.remove(entity.getId());


### PR DESCRIPTION
courtesy of @dktapps

explanation:

**Before patch**:
Chunk is unloaded and saved. All entities on the chunk are saved. Level::removeEntity is called on all entities in that chunk to remove them.
Level::removeEntity kills non-player entities. Result is items and XP being spawned in an unloaded chunk.
Movement updates to these entitities (falling checks etc.) trigger requests to the blocks around the entities. Because the entities are in unloaded chunks, these requests cause the chunks to be reloaded. When the chunk is reloaded, the saved entities are spawned again.
Process repeats, leaking more and more entities until memory limit is exhausted.

**After patch**:
Chunk is unloaded and saved. All entities on the chunk are saved. Level::removeEntity is called on all entities in that chunk to remove them.
Because Level::removeEntity now uses close() instead of kill(), no items or exp are dropped, which prevents the leak from beginning.