### PR TITLE
Add additional method to process batch packets. 

### DIFF
--- a/src/main/java/cn/nukkit/network/Network.java
+++ b/src/main/java/cn/nukkit/network/Network.java
@@ -184,9 +184,7 @@ public class Network {
             switch (packet.pid()){
                 case ProtocolInfo.USE_ITEM_PACKET:
                     // Prevent double fire of PlayerInteractEvent
-                    if (filter.contains(ProtocolInfo.USE_ITEM_PACKET)) {
-                        filter.remove((Byte) ProtocolInfo.USE_ITEM_PACKET);
-                    } else {
+                    if (!filter.contains(ProtocolInfo.USE_ITEM_PACKET)) {
                         player.handleDataPacket(packet);
                         filter.add(ProtocolInfo.USE_ITEM_PACKET);
                     }


### PR DESCRIPTION
This method is required to perform additional analyses and filter unnecessary packets. Now it fix double fire of PlayerInteractEvent