### PR TITLE
Add 'movable' to player

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -176,6 +176,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     protected boolean autoJump = true;
 
     protected boolean allowFlight = false;
+    
+    public boolean movable = true;
 
     private final Map<Integer, Boolean> needACK = new HashMap<>();
 
@@ -1886,7 +1888,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 Vector3 newPos = new Vector3(movePlayerPacket.x, movePlayerPacket.y - this.getEyeHeight(), movePlayerPacket.z);
 
                 boolean revert = false;
-                if (!this.isAlive() || !this.spawned) {
+                if (!this.isAlive() || !this.spawned || !this.movable) {
                     revert = true;
                     this.forceMovement = new Vector3(this.x, this.y, this.z);
                 }


### PR DESCRIPTION
Hi,everyone!
These changes are expected to let the plugin developers to control the
player's movement more convenient and efficiently without listening
'PlayerMoveEvent' all the time.
For example,some game plugins may cancel player's movement before the
game start.

@EventHandler
public void onPlayerMove(PlayerMoveEvent e){
    if(this.isGameStarted()){
    //skip codes...
        e.setCancelled(true);
    }
}

Instead,you can use 'p.movable = false;' when they joined the game,use
'p.movable = true;' when the game started.

Hope you like it! :)