### PR TITLE
Names with spaces.

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1837,7 +1837,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         char c = loginPacket.username.charAt(i);
                         if ((c >= 'a' && c <= 'z') ||
                                 (c >= 'A' && c <= 'Z') ||
-                                (c >= '0' && c <= '9') || c == '_'
+                                (c >= '0' && c <= '9') ||
+                                c == '_' || c == ' '
                                 ) {
                             continue;
                         }

--- a/src/main/java/cn/nukkit/command/SimpleCommandMap.java
+++ b/src/main/java/cn/nukkit/command/SimpleCommandMap.java
@@ -163,7 +163,7 @@ public class SimpleCommandMap implements CommandMap {
 
             if (sb.charAt(i) == ' ' && notQuoted) {
                 String arg = sb.substring(start, i);
-                if(!arg.isEmpty()){
+                if(!arg.isEmpty()) {
                     args.add(arg);
                 }
                 start = i + 1;

--- a/src/main/java/cn/nukkit/command/SimpleCommandMap.java
+++ b/src/main/java/cn/nukkit/command/SimpleCommandMap.java
@@ -141,9 +141,47 @@ public class SimpleCommandMap implements CommandMap {
         return true;
     }
 
+    private String[] parseArguments(String cmdLine) {
+        StringBuilder sb = new StringBuilder(cmdLine);
+        Vector<String> args = new Vector<>();
+        boolean notQuoted = true;
+        int start = 0;
+
+        for (int i = 0; i < sb.length(); i++) {
+            if (i != 0 && sb.charAt(i - 1) == '\\') {
+                if ((sb.charAt(i) == '"' || sb.charAt(i) == ' ')) {
+                    sb.deleteCharAt(i - 1);
+                    --i;
+                    continue;
+                }
+
+                if (sb.charAt(i) == '\\') {
+                    sb.deleteCharAt(i - 1);
+                    continue;
+                }
+            }
+
+            if (sb.charAt(i) == ' ' && notQuoted) {
+                String arg = sb.substring(start, i);
+                if(!arg.isEmpty())
+                    args.add(arg);
+                start = i + 1;
+            } else if (sb.charAt(i) == '"') {
+                sb.deleteCharAt(i);
+                --i;
+                notQuoted = !notQuoted;
+            }
+        }
+
+        String arg = sb.substring(start);
+        if(!arg.isEmpty())
+            args.add(arg);
+        return args.toArray(new String[0]);
+    }
+
     @Override
     public boolean dispatch(CommandSender sender, String cmdLine) {
-        String[] args = cmdLine.split(" ");
+        String[] args = parseArguments(cmdLine);
 
         if (args.length == 0) {
             return false;

--- a/src/main/java/cn/nukkit/command/SimpleCommandMap.java
+++ b/src/main/java/cn/nukkit/command/SimpleCommandMap.java
@@ -163,7 +163,7 @@ public class SimpleCommandMap implements CommandMap {
 
             if (sb.charAt(i) == ' ' && notQuoted) {
                 String arg = sb.substring(start, i);
-                if(!arg.isEmpty()) {
+                if (!arg.isEmpty()) {
                     args.add(arg);
                 }
                 start = i + 1;
@@ -175,7 +175,7 @@ public class SimpleCommandMap implements CommandMap {
         }
 
         String arg = sb.substring(start);
-        if(!arg.isEmpty()) {
+        if (!arg.isEmpty()) {
             args.add(arg);
         }
         return args.toArray(new String[0]);

--- a/src/main/java/cn/nukkit/command/SimpleCommandMap.java
+++ b/src/main/java/cn/nukkit/command/SimpleCommandMap.java
@@ -163,8 +163,9 @@ public class SimpleCommandMap implements CommandMap {
 
             if (sb.charAt(i) == ' ' && notQuoted) {
                 String arg = sb.substring(start, i);
-                if(!arg.isEmpty())
+                if(!arg.isEmpty()){
                     args.add(arg);
+                }
                 start = i + 1;
             } else if (sb.charAt(i) == '"') {
                 sb.deleteCharAt(i);
@@ -174,8 +175,9 @@ public class SimpleCommandMap implements CommandMap {
         }
 
         String arg = sb.substring(start);
-        if(!arg.isEmpty())
+        if(!arg.isEmpty()) {
             args.add(arg);
+        }
         return args.toArray(new String[0]);
     }
 


### PR DESCRIPTION
And changes in command processing related to them. Escaping of spaces, escaping of quotes, escaping of escaping... Do we need to go deeper?

A small tutorial:
Space can be escaped like this - `this\ is\ the\ same\ argument`
and like this - `"this is one argument too"`,
you can escape the quotes like this - `\"`,
backslash itself can be escaped too - `\\`.