### PR TITLE
Fixed Enchating (#963)

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3564,6 +3564,12 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         this.exp = exp;
         this.expLevel = level;
 
+        int most = calculateRequireExperience(level);
+        while (exp >= most) {  //Level Up!
+            exp = exp - most;
+            level++;
+        }
+
         this.sendExperienceLevel(level);
         this.sendExperience(exp);
     }

--- a/src/main/java/cn/nukkit/inventory/EnchantInventory.java
+++ b/src/main/java/cn/nukkit/inventory/EnchantInventory.java
@@ -204,7 +204,7 @@ public class EnchantInventory extends ContainerInventory {
                     int level = who.getExperienceLevel();
                     int exp = who.getExperience();
                     int cost = this.entries[i].getCost();
-                    if (lapis.getId() == Item.DYE && lapis.getDamage() == ItemDye.BLUE && lapis.getCount() > i && level >= cost) {
+                    if (lapis.getId() == Item.DYE && lapis.getDamage() == ItemDye.YELLOW && lapis.getCount() > i && level >= cost) {
                         result.addEnchantment(enchantments);
                         this.setItem(0, result);
                         lapis.setCount(lapis.getCount() - i - 1);


### PR DESCRIPTION
It was pretty simple to fix... It was looking for Blue which is 11 when it should have been looking for Yellow which is 4.
Since in MCPE 4 Is the Metadata for Lapis Dye.

I updated the Experience feature because you would get an error sometimes.