### PR TITLE
DyeColor enum

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockCarpet.java
+++ b/src/main/java/cn/nukkit/block/BlockCarpet.java
@@ -2,10 +2,10 @@ package cn.nukkit.block;
 
 import cn.nukkit.Player;
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemDye;
 import cn.nukkit.level.Level;
 import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.utils.BlockColor;
+import cn.nukkit.utils.DyeColor;
 
 /**
  * Created on 2015/11/24 by xtypr.
@@ -18,6 +18,10 @@ public class BlockCarpet extends BlockFlowable {
 
     public BlockCarpet(int meta) {
         super(meta);
+    }
+
+    public BlockCarpet(DyeColor dyeColor) {
+        this(dyeColor.getWoolData());
     }
 
     @Override
@@ -42,7 +46,7 @@ public class BlockCarpet extends BlockFlowable {
 
     @Override
     public String getName() {
-        return ItemDye.getColorName(meta) + " Carpet";
+        return DyeColor.getByWoolData(meta) + " Carpet";
     }
 
     @Override
@@ -83,7 +87,11 @@ public class BlockCarpet extends BlockFlowable {
 
     @Override
     public BlockColor getColor() {
-        return BlockColor.getDyeColor(meta);
+        return DyeColor.getByWoolData(meta).getColor();
+    }
+
+    public DyeColor getDyeColor() {
+        return DyeColor.getByWoolData(meta);
     }
 
 }

--- a/src/main/java/cn/nukkit/block/BlockClayHardened.java
+++ b/src/main/java/cn/nukkit/block/BlockClayHardened.java
@@ -3,6 +3,7 @@ package cn.nukkit.block;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.utils.BlockColor;
+import cn.nukkit.utils.DyeColor;
 
 /**
  * Created on 2015/11/24 by xtypr.
@@ -15,6 +16,10 @@ public class BlockClayHardened extends BlockSolid {
 
     public BlockClayHardened(int meta) {
         super(0);
+    }
+
+    public BlockClayHardened(DyeColor dyeColor) {
+        this(dyeColor.getWoolData());
     }
 
     @Override
@@ -55,6 +60,10 @@ public class BlockClayHardened extends BlockSolid {
 
     @Override
     public BlockColor getColor() {
-        return BlockColor.ADOBE_BLOCK_COLOR;
+        return DyeColor.getByWoolData(meta).getColor();
+    }
+
+    public DyeColor getDyeColor() {
+        return DyeColor.getByWoolData(meta);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockClayStained.java
+++ b/src/main/java/cn/nukkit/block/BlockClayStained.java
@@ -1,9 +1,9 @@
 package cn.nukkit.block;
 
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemDye;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.utils.BlockColor;
+import cn.nukkit.utils.DyeColor;
 
 /**
  * Created on 2015/12/2 by xtypr.
@@ -19,9 +19,13 @@ public class BlockClayStained extends BlockSolid {
         super(meta);
     }
 
+    public BlockClayStained(DyeColor dyeColor) {
+        this(dyeColor.getWoolData());
+    }
+
     @Override
     public String getName() {
-        return ItemDye.getColorName(meta) + " Stained Clay";
+        return getDyeColor().getName() + " Stained Clay";
     }
 
     @Override
@@ -55,7 +59,11 @@ public class BlockClayStained extends BlockSolid {
 
     @Override
     public BlockColor getColor() {
-        return BlockColor.getDyeColor(meta);
+        return DyeColor.getByWoolData(meta).getColor();
+    }
+
+    public DyeColor getDyeColor() {
+        return DyeColor.getByWoolData(meta);
     }
 
 }

--- a/src/main/java/cn/nukkit/block/BlockFarmland.java
+++ b/src/main/java/cn/nukkit/block/BlockFarmland.java
@@ -62,11 +62,11 @@ public class BlockFarmland extends BlockTransparent {
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_RANDOM) {
             Vector3 v = new Vector3();
-            
+
             if (this.level.getBlock(v.setComponents(x, this.y + 1, z)) instanceof BlockCrops) {
                 return 0;
             }
-            
+
             boolean found = false;
 
             for (int x = (int) this.x - 1; x <= this.x + 1; x++) {

--- a/src/main/java/cn/nukkit/block/BlockWool.java
+++ b/src/main/java/cn/nukkit/block/BlockWool.java
@@ -1,8 +1,8 @@
 package cn.nukkit.block;
 
-import cn.nukkit.item.ItemDye;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.utils.BlockColor;
+import cn.nukkit.utils.DyeColor;
 
 /**
  * Created on 2015/12/2 by xtypr.
@@ -18,9 +18,13 @@ public class BlockWool extends BlockSolid {
         super(meta);
     }
 
+    public BlockWool(DyeColor dyeColor) {
+        this(dyeColor.getWoolData());
+    }
+
     @Override
     public String getName() {
-        return ItemDye.getColorName(meta) + " Wool";
+        return getDyeColor().getName() + " Wool";
     }
 
     @Override
@@ -55,6 +59,10 @@ public class BlockWool extends BlockSolid {
 
     @Override
     public BlockColor getColor() {
-        return BlockColor.getDyeColor(meta);
+        return DyeColor.getByWoolData(meta).getColor();
+    }
+
+    public DyeColor getDyeColor() {
+        return DyeColor.getByWoolData(meta);
     }
 }

--- a/src/main/java/cn/nukkit/inventory/EnchantInventory.java
+++ b/src/main/java/cn/nukkit/inventory/EnchantInventory.java
@@ -4,13 +4,13 @@ import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBookEnchanted;
-import cn.nukkit.item.ItemDye;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.item.enchantment.EnchantmentEntry;
 import cn.nukkit.item.enchantment.EnchantmentList;
 import cn.nukkit.level.Position;
 import cn.nukkit.math.NukkitRandom;
 import cn.nukkit.network.protocol.CraftingDataPacket;
+import cn.nukkit.utils.DyeColor;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -204,7 +204,7 @@ public class EnchantInventory extends ContainerInventory {
                     int level = who.getExperienceLevel();
                     int exp = who.getExperience();
                     int cost = this.entries[i].getCost();
-                    if (lapis.getId() == Item.DYE && lapis.getDamage() == ItemDye.BLUE && lapis.getCount() > i && level >= cost) {
+                    if (lapis.getId() == Item.DYE && lapis.getDamage() == DyeColor.BLUE.getDyeData() && lapis.getCount() > i && level >= cost) {
                         result.addEnchantment(enchantments);
                         this.setItem(0, result);
                         lapis.setCount(lapis.getCount() - i - 1);

--- a/src/main/java/cn/nukkit/item/ItemColorArmor.java
+++ b/src/main/java/cn/nukkit/item/ItemColorArmor.java
@@ -2,6 +2,7 @@ package cn.nukkit.item;
 
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.utils.BlockColor;
+import cn.nukkit.utils.DyeColor;
 
 /**
  * Created by fromgate on 27.03.2016.
@@ -27,12 +28,34 @@ abstract public class ItemColorArmor extends ItemArmor {
     /**
      * Set leather armor color
      *
-     * @param dyeColor - BlockColor
+     * @param dyeColor - Dye color data value
      * @return - Return colored item
      */
+    @Deprecated
     public ItemColorArmor setColor(int dyeColor) {
-        BlockColor blockColor = BlockColor.getDyeColor(dyeColor);
+        BlockColor blockColor = DyeColor.getByDyeData(dyeColor).getColor();
         return setColor(blockColor.getRed(), blockColor.getGreen(), blockColor.getBlue());
+    }
+
+    /**
+     * Set leather armor color
+     *
+     * @param dyeColor - DyeColor object
+     * @return - Return colored item
+     */
+    public ItemColorArmor setColor(DyeColor dyeColor) {
+        BlockColor blockColor = dyeColor.getColor();
+        return setColor(blockColor.getRed(), blockColor.getGreen(), blockColor.getBlue());
+    }
+
+    /**
+     * Set leather armor color
+     *
+     * @param color - BlockColor object
+     * @return - Return colored item
+     */
+    public ItemColorArmor setColor(BlockColor color) {
+        return setColor(color.getRed(), color.getGreen(), color.getBlue());
     }
 
     /**

--- a/src/main/java/cn/nukkit/item/ItemDye.java
+++ b/src/main/java/cn/nukkit/item/ItemDye.java
@@ -1,6 +1,7 @@
 package cn.nukkit.item;
 
 import cn.nukkit.utils.BlockColor;
+import cn.nukkit.utils.DyeColor;
 
 /**
  * author: MagicDroidX
@@ -8,22 +9,38 @@ import cn.nukkit.utils.BlockColor;
  */
 public class ItemDye extends Item {
 
-    public static final int WHITE = 0;
-    public static final int ORANGE = 1;
-    public static final int MAGENTA = 2;
-    public static final int LIGHT_BLUE = 3;
-    public static final int YELLOW = 4;
-    public static final int LIME = 5;
-    public static final int PINK = 6;
-    public static final int GRAY = 7;
-    public static final int LIGHT_GRAY = 8;
-    public static final int CYAN = 9;
-    public static final int PURPLE = 10;
-    public static final int BLUE = 11;
-    public static final int BROWN = 12;
-    public static final int GREEN = 13;
-    public static final int RED = 14;
-    public static final int BLACK = 15;
+    @Deprecated
+    public static final int WHITE = DyeColor.WHITE.getDyeData();
+    @Deprecated
+    public static final int ORANGE = DyeColor.ORANGE.getDyeData();
+    @Deprecated
+    public static final int MAGENTA = DyeColor.MAGENTA.getDyeData();
+    @Deprecated
+    public static final int LIGHT_BLUE = DyeColor.LIGHT_BLUE.getDyeData();
+    @Deprecated
+    public static final int YELLOW = DyeColor.YELLOW.getDyeData();
+    @Deprecated
+    public static final int LIME = DyeColor.LIME.getDyeData();
+    @Deprecated
+    public static final int PINK = DyeColor.PINK.getDyeData();
+    @Deprecated
+    public static final int GRAY = DyeColor.GRAY.getDyeData();
+    @Deprecated
+    public static final int LIGHT_GRAY = DyeColor.LIGHT_GRAY.getDyeData();
+    @Deprecated
+    public static final int CYAN = DyeColor.CYAN.getDyeData();
+    @Deprecated
+    public static final int PURPLE = DyeColor.PURPLE.getDyeData();
+    @Deprecated
+    public static final int BLUE = DyeColor.BLUE.getDyeData();
+    @Deprecated
+    public static final int BROWN = DyeColor.BROWN.getDyeData();
+    @Deprecated
+    public static final int GREEN = DyeColor.GREEN.getDyeData();
+    @Deprecated
+    public static final int RED = DyeColor.RED.getDyeData();
+    @Deprecated
+    public static final int BLACK = DyeColor.BLACK.getDyeData();
 
     public ItemDye() {
         this(0, 1);
@@ -33,68 +50,29 @@ public class ItemDye extends Item {
         this(meta, 1);
     }
 
-    public ItemDye(Integer meta, int count) {
-        super(DYE, meta, count, "Dye");
+    public ItemDye(DyeColor dyeColor) {
+        this(dyeColor.getDyeData(), 1);
     }
 
+    public ItemDye(DyeColor dyeColor, int amount) {
+        this(dyeColor.getDyeData(), amount);
+    }
+
+    public ItemDye(Integer meta, int amount) {
+        super(DYE, meta, amount, "Dye");
+    }
+
+    @Deprecated
     public static BlockColor getColor(int meta) {
-        switch (meta & 0x0f) {
-            case WHITE:
-                return BlockColor.WHITE_BLOCK_COLOR;
-            case ORANGE:
-                return BlockColor.ORANGE_BLOCK_COLOR;
-            case MAGENTA:
-                return BlockColor.MAGENTA_BLOCK_COLOR;
-            case LIGHT_BLUE:
-                return BlockColor.LIGHT_BLUE_BLOCK_COLOR;
-            case YELLOW:
-                return BlockColor.YELLOW_BLOCK_COLOR;
-            case LIME:
-                return BlockColor.LIME_BLOCK_COLOR;
-            case PINK:
-                return BlockColor.PINK_BLOCK_COLOR;
-            case GRAY:
-                return BlockColor.GRAY_BLOCK_COLOR;
-            case LIGHT_GRAY:
-                return BlockColor.LIGHT_GRAY_BLOCK_COLOR;
-            case CYAN:
-                return BlockColor.CYAN_BLOCK_COLOR;
-            case PURPLE:
-                return BlockColor.PURPLE_BLOCK_COLOR;
-            case BLUE:
-                return BlockColor.BLUE_BLOCK_COLOR;
-            case BROWN:
-                return BlockColor.BROWN_BLOCK_COLOR;
-            case GREEN:
-                return BlockColor.GREEN_BLOCK_COLOR;
-            case RED:
-                return BlockColor.RED_BLOCK_COLOR;
-            case BLACK:
-                return BlockColor.BLACK_BLOCK_COLOR;
-            default:
-                return BlockColor.WHITE_BLOCK_COLOR;
-        }
+        return DyeColor.getByDyeData(meta).getColor();
     }
 
+    public DyeColor getDyeColor() {
+        return DyeColor.getByDyeData(meta);
+    }
+
+    @Deprecated
     public static String getColorName(int meta) {
-        String[] names = new String[]{
-                "White",
-                "Orange",
-                "Magenta",
-                "Light Blue",
-                "Yellow",
-                "Lime",
-                "Pink",
-                "Gray",
-                "Light Gray",
-                "Cyan",
-                "Purple",
-                "Blue",
-                "Brown",
-                "Green",
-                "Red",
-                "Black",
-        };
-        return names[meta & 0x0f];
+        return DyeColor.getByDyeData(meta).getName();
     }
 }

--- a/src/main/java/cn/nukkit/item/randomitem/Fishing.java
+++ b/src/main/java/cn/nukkit/item/randomitem/Fishing.java
@@ -1,9 +1,9 @@
 package cn.nukkit.item.randomitem;
 
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemDye;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.potion.Potion;
+import cn.nukkit.utils.DyeColor;
 
 import static cn.nukkit.item.randomitem.RandomItem.*;
 
@@ -36,7 +36,7 @@ public final class Fishing {
     public static final Selector JUNK_STRING_ITEM = putSelector(new ConstantItemSelector(Item.STRING, JUNKS), 0.06F);
     public static final Selector JUNK_WATTER_BOTTLE = putSelector(new ConstantItemSelector(Item.POTION, Potion.NO_EFFECTS, JUNKS), 0.12F);
     public static final Selector JUNK_BONE = putSelector(new ConstantItemSelector(Item.BONE, JUNKS), 0.12F);
-    public static final Selector JUNK_INK_SAC = putSelector(new ConstantItemSelector(Item.DYE, ItemDye.BLACK, 10, JUNKS), 0.012F);
+    public static final Selector JUNK_INK_SAC = putSelector(new ConstantItemSelector(Item.DYE, DyeColor.BLACK.getDyeData(), 10, JUNKS), 0.012F);
     public static final Selector JUNK_TRIPWIRE_HOOK = putSelector(new ConstantItemSelector(Item.TRIPWIRE_HOOK, JUNKS), 0.12F);
 
     public static Item getFishingResult(Item rod) {

--- a/src/main/java/cn/nukkit/utils/BlockColor.java
+++ b/src/main/java/cn/nukkit/utils/BlockColor.java
@@ -1,7 +1,5 @@
 package cn.nukkit.utils;
 
-import cn.nukkit.item.ItemDye;
-
 /**
  * Created by Snake1999 on 2016/1/10.
  * Package cn.nukkit.utils in project nukkit
@@ -78,8 +76,8 @@ public class BlockColor extends java.awt.Color {
         super(r, g, b);
     }
 
+    @Deprecated
     public static BlockColor getDyeColor(int dyeColorMeta) {
-        return ItemDye.getColor(dyeColorMeta);
+        return DyeColor.getByDyeData(dyeColorMeta).getColor();
     }
-
 }

--- a/src/main/java/cn/nukkit/utils/DyeColor.java
+++ b/src/main/java/cn/nukkit/utils/DyeColor.java
@@ -1,0 +1,75 @@
+package cn.nukkit.utils;
+
+public enum DyeColor {
+
+
+    BLACK(0, 15, "Black", BlockColor.BLACK_BLOCK_COLOR),
+    RED(1, 14, "Red", BlockColor.RED_BLOCK_COLOR),
+    GREEN(2, 13, "Green", BlockColor.GREEN_BLOCK_COLOR),
+    BROWN(3, 12, "Brown", BlockColor.BROWN_BLOCK_COLOR),
+    BLUE(4, 11, "Blue", BlockColor.BLUE_BLOCK_COLOR),
+    PURPLE(5, 10, "Purple", BlockColor.PURPLE_BLOCK_COLOR),
+    CYAN(6, 9, "Cyan", BlockColor.CYAN_BLOCK_COLOR),
+    LIGHT_GRAY(7, 8, "Light Gray", BlockColor.LIGHT_GRAY_BLOCK_COLOR),
+    GRAY(8, 7, "Gray", BlockColor.GRAY_BLOCK_COLOR),
+    PINK(9, 6, "Pink", BlockColor.PINK_BLOCK_COLOR),
+    LIME(10, 5, "Lime", BlockColor.LIME_BLOCK_COLOR),
+    YELLOW(11, 4, "Yellow", BlockColor.YELLOW_BLOCK_COLOR),
+    LIGHT_BLUE(12, 3, "Light Blue", BlockColor.LIGHT_BLUE_BLOCK_COLOR),
+    MAGENTA(13, 2, "Magenta", BlockColor.MAGENTA_BLOCK_COLOR),
+    ORANGE(14, 1, "Orange", BlockColor.ORANGE_BLOCK_COLOR),
+    WHITE(15, 0, "White", BlockColor.WHITE_BLOCK_COLOR);
+
+
+    private int dyeColorMeta;
+    private int woolColorMeta;
+    private String colorName;
+    private BlockColor blockColor;
+
+
+    private final static DyeColor[] BY_WOOL_DATA;
+    private final static DyeColor[] BY_DYE_DATA;
+
+    DyeColor(int dyeColorMeta, int woolColorMeta, String colorName, BlockColor blockColor) {
+        this.dyeColorMeta = dyeColorMeta;
+        this.woolColorMeta = woolColorMeta;
+        this.colorName = colorName;
+        this.blockColor = blockColor;
+    }
+
+    public BlockColor getColor() {
+        return this.blockColor;
+    }
+
+    public int getDyeData() {
+        return this.dyeColorMeta;
+    }
+
+    public int getWoolData() {
+        return this.woolColorMeta;
+    }
+
+    public String getName() {
+        return this.colorName;
+    }
+
+    static {
+        BY_DYE_DATA = values();
+        BY_WOOL_DATA = values();
+
+        for (DyeColor color : values()) {
+            BY_WOOL_DATA[color.woolColorMeta & 0x0f] = color;
+            BY_DYE_DATA[color.dyeColorMeta & 0x0f] = color;
+        }
+    }
+
+    public static DyeColor getByDyeData(int dyeColorMeta) {
+        return BY_DYE_DATA[dyeColorMeta & 0x0f];
+    }
+
+    public static DyeColor getByWoolData(int woolColorMeta) {
+        return BY_WOOL_DATA[woolColorMeta & 0x0f];
+    }
+
+
+}


### PR DESCRIPTION
Added DyeColor enum. This enum allows to get color data of dye and wool and clay blocks. And could be used to construct dyes, wool, carpet, stained clay.
BTW, enchantment confusion (lapis vs yellow dye) fixed too.
No plugins were harmed: old ItemDye fields and methods are marked as deprecated but still could used by plugins.