### PR TITLE
SimpleCommand API

### DIFF
--- a/src/main/java/cn/nukkit/command/CommandMap.java
+++ b/src/main/java/cn/nukkit/command/CommandMap.java
@@ -14,6 +14,8 @@ public interface CommandMap {
 
     boolean register(String fallbackPrefix, Command command, String label);
 
+    void registerSimpleCommands(Object object);
+
     boolean dispatch(CommandSender sender, String cmdLine);
 
     void clearCommands();

--- a/src/main/java/cn/nukkit/command/SimpleCommandMap.java
+++ b/src/main/java/cn/nukkit/command/SimpleCommandMap.java
@@ -2,11 +2,15 @@ package cn.nukkit.command;
 
 import cn.nukkit.Server;
 import cn.nukkit.command.defaults.*;
+import cn.nukkit.command.simple.Arguments;
+import cn.nukkit.command.simple.ForbidConsole;
+import cn.nukkit.command.simple.SimpleCommand;
 import cn.nukkit.lang.TranslationContainer;
 import cn.nukkit.utils.MainLogger;
 import cn.nukkit.utils.TextFormat;
 import cn.nukkit.utils.Utils;
 
+import java.lang.reflect.Method;
 import java.util.*;
 
 /**
@@ -110,6 +114,28 @@ public class SimpleCommandMap implements CommandMap {
         return registered;
     }
 
+    @Override
+    public void registerSimpleCommands(Object object) {
+        for (Method method : object.getClass().getDeclaredMethods()) {
+            cn.nukkit.command.simple.Command def = method.getAnnotation(cn.nukkit.command.simple.Command.class);
+            if (def != null) {
+                SimpleCommand sc = new SimpleCommand(object, method, def.name(), def.description(), def.usageMessage(), def.aliases());
+
+                Arguments args = method.getAnnotation(Arguments.class);
+                if (args != null) {
+                    sc.setMaxArgs(args.max());
+                    sc.setMinArgs(args.min());
+                }
+
+                if (method.isAnnotationPresent(ForbidConsole.class)) {
+                    sc.setForbidConsole(true);
+                }
+
+                this.register(def.name(), sc);
+            }
+        }
+    }
+
     private boolean registerAlias(Command command, boolean isAlias, String fallbackPrefix, String label) {
         this.knownCommands.put(fallbackPrefix + ":" + label, command);
 
@@ -193,7 +219,7 @@ public class SimpleCommandMap implements CommandMap {
             target.execute(sender, sentCommandLabel, args);
         } catch (Exception e) {
             sender.sendMessage(new TranslationContainer(TextFormat.RED + "%commands.generic.exception"));
-            this.server.getLogger().critical(this.server.getLanguage().translateString("nukkit.command.exception", new String[]{cmdLine, target.toString(), Utils.getExceptionMessage(e)}));
+            this.server.getLogger().critical(this.server.getLanguage().translateString("nukkit.command.exception", cmdLine, target.toString(), Utils.getExceptionMessage(e)));
             MainLogger logger = sender.getServer().getLogger();
             if (logger != null) {
                 logger.logException(e);

--- a/src/main/java/cn/nukkit/command/SimpleCommandMap.java
+++ b/src/main/java/cn/nukkit/command/SimpleCommandMap.java
@@ -3,6 +3,7 @@ package cn.nukkit.command;
 import cn.nukkit.Server;
 import cn.nukkit.command.defaults.*;
 import cn.nukkit.command.simple.Arguments;
+import cn.nukkit.command.simple.CommandPermission;
 import cn.nukkit.command.simple.ForbidConsole;
 import cn.nukkit.command.simple.SimpleCommand;
 import cn.nukkit.lang.TranslationContainer;
@@ -125,6 +126,11 @@ public class SimpleCommandMap implements CommandMap {
                 if (args != null) {
                     sc.setMaxArgs(args.max());
                     sc.setMinArgs(args.min());
+                }
+
+                CommandPermission perm = method.getAnnotation(CommandPermission.class);
+                if (perm != null) {
+                    sc.setPermission(perm.value());
                 }
 
                 if (method.isAnnotationPresent(ForbidConsole.class)) {

--- a/src/main/java/cn/nukkit/command/simple/Arguments.java
+++ b/src/main/java/cn/nukkit/command/simple/Arguments.java
@@ -1,0 +1,16 @@
+package cn.nukkit.command.simple;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Tee7even
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Arguments {
+    int min() default 0;
+    int max() default 0;
+}

--- a/src/main/java/cn/nukkit/command/simple/Command.java
+++ b/src/main/java/cn/nukkit/command/simple/Command.java
@@ -1,0 +1,18 @@
+package cn.nukkit.command.simple;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Tee7even
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Command {
+    String name();
+    String description() default "";
+    String usageMessage() default "";
+    String[] aliases() default {};
+}

--- a/src/main/java/cn/nukkit/command/simple/CommandPermission.java
+++ b/src/main/java/cn/nukkit/command/simple/CommandPermission.java
@@ -1,0 +1,15 @@
+package cn.nukkit.command.simple;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Tee7even
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CommandPermission {
+    String value();
+}

--- a/src/main/java/cn/nukkit/command/simple/ForbidConsole.java
+++ b/src/main/java/cn/nukkit/command/simple/ForbidConsole.java
@@ -1,0 +1,14 @@
+package cn.nukkit.command.simple;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Tee7even
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ForbidConsole {
+}

--- a/src/main/java/cn/nukkit/command/simple/SimpleCommand.java
+++ b/src/main/java/cn/nukkit/command/simple/SimpleCommand.java
@@ -1,0 +1,78 @@
+package cn.nukkit.command.simple;
+
+import cn.nukkit.Server;
+import cn.nukkit.command.Command;
+import cn.nukkit.command.CommandSender;
+import cn.nukkit.command.ConsoleCommandSender;
+import cn.nukkit.lang.TranslationContainer;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author Tee7even
+ */
+public class SimpleCommand extends Command {
+    private Object object;
+    private Method method;
+    private boolean forbidConsole;
+    private int maxArgs;
+    private int minArgs;
+
+    public SimpleCommand(Object object, Method method, String name, String description, String usageMessage, String[] aliases) {
+        super(name, description, usageMessage, aliases);
+        this.object = object;
+        this.method = method;
+    }
+
+    public void setForbidConsole(boolean forbidConsole) {
+        this.forbidConsole = forbidConsole;
+    }
+
+    public void setMaxArgs(int maxArgs) {
+        this.maxArgs = maxArgs;
+    }
+
+    public void setMinArgs(int minArgs) {
+        this.minArgs = minArgs;
+    }
+
+    public void sendUsageMessage(CommandSender sender) {
+        if (!this.usageMessage.equals("")) {
+            sender.sendMessage(new TranslationContainer("commands.generic.usage", this.usageMessage));
+        }
+    }
+
+    public void sendInGameMessage(CommandSender sender) {
+        sender.sendMessage(new TranslationContainer("commands.generic.ingame"));
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String commandLabel, String[] args) {
+        if (this.forbidConsole && sender instanceof ConsoleCommandSender) {
+            this.sendInGameMessage(sender);
+            return false;
+        } else if (!this.testPermission(sender)) {
+            return false;
+        } else if (this.maxArgs != 0 && args.length > this.maxArgs) {
+            this.sendUsageMessage(sender);
+            return false;
+        } else if (this.minArgs != 0 && args.length < this.minArgs) {
+            this.sendUsageMessage(sender);
+            return false;
+        }
+
+        boolean success = false;
+
+        try {
+            success = (Boolean) this.method.invoke(this.object, sender, commandLabel, args);
+        } catch (Exception exception) {
+            Server.getInstance().getLogger().logException(exception);
+        }
+
+        if (!success) {
+            this.sendUsageMessage(sender);
+        }
+
+        return success;
+    }
+}


### PR DESCRIPTION
Allows simple command handling, when there's much commands (compared to both creating a separate class for every command and switching them in "onCommand" method). =)

## Usage
```
public class SomeCommandsClass { //Can be any class, but it makes sense to create a class just for commands :)
    @Command( //This annotation is necessary to register a command
            name = "test", //this annotation field is necessary
            description = "Just a SimpleCommand test",
            usageMessage = "/test <> []",
            aliases = {"t", "tst"}
    )
    @Arguments(min = 1, max = 2) //Optional, you can specify either maximum or minimum number of arguments
    @CommandPermission("simplecommand.test") //Optional
    @ForbidConsole //Optional
    public boolean test(CommandSender sender, String label, String[] args) {
        sender.sendMessage("Hello, sender! Your args:");
        for (String arg : args) {
            sender.sendMessage(arg);
        }
        return true; //If false is returned, sender will get a usage message
    }
}
```
To register commands in the object, call to `registerSimpleCommands` in, for example, `onEnable` method of your plugin:
```
    @Override
    public void onEnable(){
        getServer().getCommandMap().registerSimpleCommands(new SomeCommandsClass());
    }
```