### PR TITLE
Some fixes / optimizations

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -42,7 +42,6 @@ import cn.nukkit.level.ChunkLoader;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Location;
 import cn.nukkit.level.Position;
-import cn.nukkit.level.format.Chunk;
 import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.level.format.generic.BaseFullChunk;
 import cn.nukkit.level.particle.CriticalParticle;
@@ -70,7 +69,6 @@ import cn.nukkit.timings.Timings;
 import cn.nukkit.utils.Binary;
 import cn.nukkit.utils.TextFormat;
 import cn.nukkit.utils.Zlib;
-
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.*;
@@ -159,10 +157,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
     protected float stepHeight = 0.6f;
 
-    public Map<String, Boolean> usedChunks = new HashMap<>();
+    public Map<Long, Boolean> usedChunks = new HashMap<>();
 
     protected int chunkLoadCount = 0;
-    protected Map<String, Integer> loadQueue = new HashMap<>();
+    protected Map<Long, Integer> loadQueue = new HashMap<>();
     protected int nextChunkOrderRun = 5;
 
     protected Map<UUID, Player> hiddenPlayers = new HashMap<>();
@@ -527,10 +525,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     protected boolean switchLevel(Level targetLevel) {
         Level oldLevel = this.level;
         if (super.switchLevel(targetLevel)) {
-            for (String index : new ArrayList<>(this.usedChunks.keySet())) {
-                Chunk.Entry chunkEntry = Level.getChunkXZ(index);
-                int chunkX = chunkEntry.chunkX;
-                int chunkZ = chunkEntry.chunkZ;
+            for (long index : new ArrayList<>(this.usedChunks.keySet())) {
+                int chunkX = Level.getHashX(index);
+                int chunkZ = Level.getHashZ(index);
                 this.unloadChunk(chunkX, chunkZ, oldLevel);
             }
 
@@ -550,7 +547,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
     public void unloadChunk(int x, int z, Level level) {
         level = level == null ? this.level : level;
-        String index = Level.chunkHash(x, z);
+        long index = Level.chunkHash(x, z);
         if (this.usedChunks.containsKey(index)) {
             for (Entity entity : level.getChunkEntities(x, z).values()) {
                 if (entity != this) {
@@ -629,23 +626,21 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
         int count = 0;
 
-        List<Map.Entry<String, Integer>> entryList = new ArrayList<>(this.loadQueue.entrySet());
-        entryList.sort(new Comparator<Map.Entry<String, Integer>>() {
+        List<Map.Entry<Long, Integer>> entryList = new ArrayList<>(this.loadQueue.entrySet());
+        entryList.sort(new Comparator<Map.Entry<Long, Integer>>() {
             @Override
-            public int compare(Map.Entry<String, Integer> o1, Map.Entry<String, Integer> o2) {
+            public int compare(Map.Entry<Long, Integer> o1, Map.Entry<Long, Integer> o2) {
                 return o1.getValue() - o2.getValue();
             }
         });
 
-        for (Map.Entry<String, Integer> entry : entryList) {
-            String index = entry.getKey();
+        for (Map.Entry<Long, Integer> entry : entryList) {
+            long index = entry.getKey();
             if (count >= this.chunksPerTick) {
                 break;
             }
-
-            Chunk.Entry chunkEntry = Level.getChunkXZ(index);
-            int chunkX = chunkEntry.chunkX;
-            int chunkZ = chunkEntry.chunkZ;
+            int chunkX = Level.getHashX(index);
+            int chunkZ = Level.getHashZ(index);
 
             ++count;
 
@@ -668,7 +663,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 this.level.requestChunk(chunkX, chunkZ, this);
             }
         }
-
         if (this.chunkLoadCount >= this.spawnThreshold && !this.spawned && this.teleportPosition == null) {
             this.doFirstSpawn();
         }
@@ -676,7 +670,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     }
 
     protected void doFirstSpawn() {
-
         this.spawned = true;
 
         this.server.sendRecipeList(this);
@@ -727,10 +720,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
         this.noDamageTicks = 60;
 
-        for (String index : this.usedChunks.keySet()) {
-            Chunk.Entry chunkEntry = Level.getChunkXZ(index);
-            int chunkX = chunkEntry.chunkX;
-            int chunkZ = chunkEntry.chunkZ;
+        for (long index : this.usedChunks.keySet()) {
+            int chunkX = Level.getHashX(index);
+            int chunkZ = Level.getHashZ(index);
             for (Entity entity : this.level.getChunkEntities(chunkX, chunkZ).values()) {
                 if (this != entity && !entity.closed && entity.isAlive()) {
                     entity.spawnTo(this);
@@ -774,8 +766,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
         this.nextChunkOrderRun = 200;
 
-        Map<String, Integer> newOrder = new HashMap<>();
-        Map<String, Boolean> lastChunk = new HashMap<>(this.usedChunks);
+        Map<Long, Integer> newOrder = new HashMap<>();
+        Map<Long, Boolean> lastChunk = new HashMap<>(this.usedChunks);
 
         int centerX = (int) this.x >> 4;
         int centerZ = (int) this.z >> 4;
@@ -787,7 +779,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 int chunkZ = z + centerZ;
                 int distance = (int) Math.sqrt((double) x * x + (double) z * z);
                 if (distance <= this.chunkRadius) {
-                    String index;
+                    long index;
                     if (!(this.usedChunks.containsKey(index = Level.chunkHash(chunkX, chunkZ))) || !this.usedChunks.get(index)) {
                         newOrder.put(index, distance);
                         count++;
@@ -797,9 +789,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             }
         }
 
-        for (String index : new ArrayList<>(lastChunk.keySet())) {
-            Chunk.Entry entry = Level.getChunkXZ(index);
-            this.unloadChunk(entry.chunkX, entry.chunkZ);
+        for (long index : new ArrayList<>(lastChunk.keySet())) {
+            this.unloadChunk(Level.getHashX(index), Level.getHashZ(index));
         }
 
         this.loadQueue = newOrder;
@@ -1207,13 +1198,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         if (!this.isAlive() || !this.spawned || this.newPosition == null || this.teleportPosition != null) {
             return;
         }
-
-
         Vector3 newPos = this.newPosition;
         double distanceSquared = newPos.distanceSquared(this);
-
         boolean revert = false;
-
         if ((distanceSquared / ((double) (tickDiff * tickDiff))) > 100 && (newPos.y - this.y) > -5) {
             revert = true;
         } else {
@@ -1231,15 +1218,16 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             }
         }
 
-        Vector2 newPosV2 = new Vector2(newPos.x, newPos.z);
-        double distance = newPosV2.distance(this.x, this.z);
+        double tdx = newPos.x - this.x;
+        double tdz = newPos.z - this.z;
+        double distance = Math.sqrt(tdx * tdx + tdz * tdz);
 
         if (!revert && distanceSquared != 0) {
             double dx = newPos.x - this.x;
             double dy = newPos.y - this.y;
             double dz = newPos.z - this.z;
 
-            this.move(dx, dy, dz);
+            this.fastMove(dx, dy, dz);
 
             double diffX = this.x - newPos.x;
             double diffY = this.y - newPos.y;
@@ -1252,9 +1240,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
             double diff = (diffX * diffX + diffY * diffY + diffZ * diffZ) / ((double) (tickDiff * tickDiff));
 
-            if (this.isSurvival()) {
+            if (!server.getAllowFlight() && this.isSurvival()) {
                 if (!this.isSleeping()) {
-                    if (diff > 0.0625) {
+                    if (diff > 0.125) {
                         PlayerInvalidMoveEvent ev;
                         this.getServer().getPluginManager().callEvent(ev = new PlayerInvalidMoveEvent(this, true));
                         if (!ev.isCancelled()) {
@@ -1286,11 +1274,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 this.level);
         Location to = this.getLocation();
 
-        double delta = Math.pow(this.lastX - to.x, 2) + Math.pow(this.lastY - to.y, 2) + Math.pow(this.lastZ - to.z, 2);
-        double deltaAngle = Math.abs(this.lastYaw - to.yaw) + Math.abs(this.lastPitch - to.pitch);
-
-        if (!revert && (delta > (1 / 16) || deltaAngle > 10)) {
-
+        if (!revert && (Math.pow(this.lastX - to.x, 2) + Math.pow(this.lastY - to.y, 2) + Math.pow(this.lastZ - to.z, 2)) > (1/16) || (Math.abs(this.lastYaw - to.yaw) + Math.abs(this.lastPitch - to.pitch)) > 10) {
             boolean isFirst = this.firstMove;
 
             this.firstMove = false;
@@ -1307,7 +1291,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 this.server.getPluginManager().callEvent(ev);
 
                 if (!(revert = ev.isCancelled())) { //Yes, this is intended
-                    if (to.distanceSquared(ev.getTo()) > 0.01) { //If plugins modify the destination
+                    if (!to.equals(ev.getTo())) { //If plugins modify the destination
                         this.teleport(ev.getTo(), null);
                     } else {
                         this.addMovement(this.x, this.y + this.getEyeHeight(), this.z, this.yaw, this.pitch, this.yaw);
@@ -1318,10 +1302,11 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             if (!this.isSpectator()) {
                 this.checkNearEntities();
             }
-
-            this.speed = from.subtract(to);
-        } else if (distanceSquared == 0) {
-            this.speed = new Vector3(0, 0, 0);
+            if (this.speed == null) speed = new Vector3(from.x - to.x, from.y - to.y, from.z - to.z);
+            else this.speed.setComponents(from.x - to.x, from.y - to.y, from.z - to.z);
+        } else {
+            if (this.speed == null) speed = new Vector3(0, 0, 0);
+            else this.speed.setComponents(0, 0, 0);
         }
 
         if (!revert && (this.isFoodEnabled() || this.getServer().getDifficulty() == 0)) {
@@ -1446,7 +1431,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         double expectedVelocity = (-this.getGravity()) / ((double) this.getDrag()) - ((-this.getGravity()) / ((double) this.getDrag())) * Math.exp(-((double) this.getDrag()) * ((double) (this.inAirTicks - this.startAirTicks)));
                         double diff = (this.speed.y - expectedVelocity) * (this.speed.y - expectedVelocity);
 
-                        if (!this.hasEffect(Effect.JUMP) && diff > 0.6 && expectedVelocity < this.speed.y && !this.server.getAllowFlight()) {
+                        if (!this.hasEffect(Effect.JUMP) && diff > 0.6 && expectedVelocity < this.speed.y) {
                             if (this.inAirTicks < 100) {
                                 //this.sendSettings();
                                 this.setMotion(new Vector3(0, expectedVelocity, 0));
@@ -3128,7 +3113,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 case ProtocolInfo.REQUEST_CHUNK_RADIUS_PACKET:
                     RequestChunkRadiusPacket requestChunkRadiusPacket = (RequestChunkRadiusPacket) packet;
                     ChunkRadiusUpdatedPacket chunkRadiusUpdatePacket = new ChunkRadiusUpdatedPacket();
-                    this.chunkRadius = Math.max(5, Math.min(requestChunkRadiusPacket.radius, this.viewDistance));
+                    this.chunkRadius = Math.max(1, Math.min(requestChunkRadiusPacket.radius, this.viewDistance));
                     chunkRadiusUpdatePacket.radius = this.chunkRadius;
                     this.dataPacket(chunkRadiusUpdatePacket);
                     break;
@@ -3312,9 +3297,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 this.removeWindow(window);
             }
 
-            for (String index : new ArrayList<>(this.usedChunks.keySet())) {
-                Chunk.Entry entry = Level.getChunkXZ(index);
-                this.level.unregisterChunkLoader(this, entry.chunkX, entry.chunkZ);
+            for (long index : new ArrayList<>(this.usedChunks.keySet())) {
+                int chunkX = Level.getHashX(index);
+                int chunkZ = Level.getHashZ(index);
+                this.level.unregisterChunkLoader(this, chunkX, chunkZ);
                 this.usedChunks.remove(index);
             }
 
@@ -3803,7 +3789,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
             for (int X = -1; X <= 1; ++X) {
                 for (int Z = -1; Z <= 1; ++Z) {
-                    String index = Level.chunkHash(chunkX + X, chunkZ + Z);
+                    long index = Level.chunkHash(chunkX + X, chunkZ + Z);
                     if (!this.usedChunks.containsKey(index) || !this.usedChunks.get(index)) {
                         return false;
                     }

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -148,6 +148,7 @@ public class Server {
     private int autoTickRateLimit = 20;
     private boolean alwaysTickPlayers = false;
     private int baseTickRate = 1;
+    private Boolean getAllowFlight = null;
 
     private int autoSaveTicker = 0;
     private int autoSaveTicks = 6000;
@@ -1034,13 +1035,9 @@ public class Server {
         if (this.tickCounter % 100 == 0) {
             for (Level level : this.levels.values()) {
                 level.clearCache();
-            }
-
-            if (this.getTicksPerSecondAverage() < 12) {
-                this.logger.warning(this.getLanguage().translateString("nukkit.server.tickOverload"));
+                level.doChunkGarbageCollection();
             }
         }
-
 
         Timings.fullServerTickTimer.stopTiming();
         //long now = System.currentTimeMillis();
@@ -1264,7 +1261,10 @@ public class Server {
     }
 
     public boolean getAllowFlight() {
-        return this.getPropertyBoolean("allow-flight", false);
+        if (getAllowFlight == null) {
+            getAllowFlight = this.getPropertyBoolean("allow-flight", false);
+        }
+        return getAllowFlight;
     }
 
     public boolean isHardcore() {

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1124,9 +1124,7 @@ public abstract class Entity extends Location implements Metadatable {
 
         AxisAlignedBB newBB = this.boundingBox.getOffsetBoundingBox(dx, dy, dz);
 
-        AxisAlignedBB[] list = this.level.getCollisionCubes(this, newBB, false);
-
-        if (list.length == 0) {
+        if (server.getAllowFlight() || !this.level.hasCollision(this, newBB, false)) {
             this.boundingBox = newBB;
         }
 

--- a/src/main/java/cn/nukkit/level/Explosion.java
+++ b/src/main/java/cn/nukkit/level/Explosion.java
@@ -12,6 +12,7 @@ import cn.nukkit.event.entity.EntityExplodeEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
 import cn.nukkit.math.AxisAlignedBB;
+import cn.nukkit.math.BlockVector3;
 import cn.nukkit.math.NukkitMath;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.nbt.tag.*;
@@ -95,7 +96,6 @@ public class Explosion {
                             if (block.getId() != 0) {
                                 blastForce -= (block.getResistance() / 5 + 0.3d) * this.stepLen;
                                 if (blastForce > 0) {
-                                    String index = Level.blockHash((int) block.x, (int) block.y, (int) block.z);
                                     if (!this.affectedBlocks.contains(block)) {
                                         this.affectedBlocks.add(block);
                                     }
@@ -115,7 +115,7 @@ public class Explosion {
 
     public boolean explodeB() {
 
-        HashMap<String, Boolean> updateBlocks = new HashMap<>();
+        HashMap<BlockVector3, Boolean> updateBlocks = new HashMap<>();
         List<Vector3> send = new ArrayList<>();
 
         Vector3 source = (new Vector3(this.source.x, this.source.y, this.source.z)).floor();
@@ -204,7 +204,7 @@ public class Explosion {
 
             for (int side = 0; side < 5; side++) {
                 Vector3 sideBlock = pos.getSide(side);
-                String index = Level.blockHash((int) sideBlock.x, (int) sideBlock.y, (int) sideBlock.z);
+                BlockVector3 index = Level.blockHash((int) sideBlock.x, (int) sideBlock.y, (int) sideBlock.z);
                 if (!this.affectedBlocks.contains(sideBlock) && !updateBlocks.containsKey(index)) {
                     BlockUpdateEvent ev = new BlockUpdateEvent(this.level.getBlock(sideBlock));
                     this.level.getServer().getPluginManager().callEvent(ev);

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -48,7 +48,7 @@ import cn.nukkit.timings.LevelTimings;
 import cn.nukkit.timings.Timings;
 import cn.nukkit.timings.TimingsHistory;
 import cn.nukkit.utils.*;
-
+import java.lang.ref.SoftReference;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -77,11 +77,14 @@ public class Level implements ChunkManager, Metadatable {
     public static final int DIMENSION_OVERWORLD = 0;
     public static final int DIMENSION_NETHER = 1;
 
+    // Lower values use less memory
+    public static final int MAX_BLOCK_CACHE = 512;
+
     private final Map<Long, BlockEntity> blockEntities = new HashMap<>();
 
-    private Map<String, Map<Long, SetEntityMotionPacket.Entry>> motionToSend = new HashMap<>();
-    private Map<String, Map<Long, MoveEntityPacket>> moveToSend = new HashMap<>();
-    private Map<String, Map<Long, MovePlayerPacket>> playerMoveToSend = new HashMap<>();
+    private Map<Long, Map<Long, SetEntityMotionPacket.Entry>> motionToSend = new HashMap<>();
+    private Map<Long, Map<Long, MoveEntityPacket>> moveToSend = new HashMap<>();
+    private Map<Long, Map<Long, MovePlayerPacket>> playerMoveToSend = new HashMap<>();
 
     private final Map<Long, Player> players = new HashMap<>();
 
@@ -91,9 +94,11 @@ public class Level implements ChunkManager, Metadatable {
 
     public final Map<Long, BlockEntity> updateBlockEntities = new HashMap<>();
 
-    private Map<String, Block> blockCache = new HashMap<>();
+    // Use a weak map to avoid OOM
+    private final Map<BlockVector3, Block> blockCache = new WeakHashMap<>();
 
-    private Map<String, DataPacket> chunkCache = new HashMap<>();
+    // Use a weak map to avoid OOM
+    private final Map<Long, DataPacket> chunkCache = new WeakHashMap<>();
 
     private boolean cacheChunks = false;
 
@@ -109,32 +114,39 @@ public class Level implements ChunkManager, Metadatable {
 
     private final Map<Integer, Integer> loaderCounter = new HashMap<>();
 
-    private final Map<String, Map<Integer, ChunkLoader>> chunkLoaders = new HashMap<>();
+    private final Map<Long, Map<Integer, ChunkLoader>> chunkLoaders = new HashMap<>();
 
-    private final Map<String, Map<Integer, Player>> playerLoaders = new HashMap<>();
+    private final Map<Long, Map<Integer, Player>> playerLoaders = new HashMap<>();
 
-    private Map<String, List<DataPacket>> chunkPackets = new HashMap<>();
+    private Map<Long, List<DataPacket>> chunkPackets = new HashMap<>();
 
-    private final Map<String, Long> unloadQueue = new HashMap<>();
+    private final Map<Long, Long> unloadQueue = new HashMap<>();
 
     private float time;
     public boolean stopTime;
 
     private String folderName;
 
-    private final Map<String, BaseFullChunk> chunks = new HashMap<>();
+    private final Map<Long, BaseFullChunk> chunks = new HashMap<>();
 
-    private Map<String, Map<String, Vector3>> changedBlocks = new HashMap<>();
+    private Vector3 mutableBlock;
+
+    // Avoid OOM, gc'd references result in whole chunk being sent (possibly higher cpu)
+    private Map<Long, SoftReference<Map<Short, Object>>> changedBlocks = new HashMap<>();
+    // Storing the vector is redundant
+    private final Object changeBlocksPresent = new Object();
+    // Storing extra blocks past 512 is redundant
+    private final Map<Short, Object> changeBlocksFullMap = new HashMap<Short, Object>() { @Override public int size() {return 32768;}};
 
     private PriorityQueue<PriorityObject> updateQueue;
-    private final Map<String, Integer> updateQueueIndex = new HashMap<>();
+    private final Map<BlockVector3, Integer> updateQueueIndex = new HashMap<>();
 
-    private final Map<String, Map<Integer, Player>> chunkSendQueue = new HashMap<>();
-    private final Map<String, Boolean> chunkSendTasks = new HashMap<>();
+    private final Map<Long, Map<Integer, Player>> chunkSendQueue = new HashMap<>();
+    private final Map<Long, Boolean> chunkSendTasks = new HashMap<>();
 
-    private final Map<String, Boolean> chunkPopulationQueue = new HashMap<>();
-    private final Map<String, Boolean> chunkPopulationLock = new HashMap<>();
-    private final Map<String, Boolean> chunkGenerationQueue = new HashMap<>();
+    private final Map<Long, Boolean> chunkPopulationQueue = new HashMap<>();
+    private final Map<Long, Boolean> chunkPopulationLock = new HashMap<>();
+    private final Map<Long, Boolean> chunkGenerationQueue = new HashMap<>();
     private int chunkGenerationQueueSize = 8;
     private int chunkPopulationQueueSize = 2;
 
@@ -153,7 +165,7 @@ public class Level implements ChunkManager, Metadatable {
     public int sleepTicks = 0;
 
     private int chunkTickRadius;
-    private Map<String, Integer> chunkTickList = new HashMap<>();
+    private Map<Long, Integer> chunkTickList = new HashMap<>();
     private int chunksPerTicks;
     private boolean clearChunksOnTick;
     private final HashMap<Integer, Class<? extends Block>> randomTickBlocks = new HashMap<Integer, Class<? extends Block>>() {
@@ -273,30 +285,51 @@ public class Level implements ChunkManager, Metadatable {
         this.tickRate = 1;
     }
 
-    public static String chunkHash(int x, int z) {
-        return x + ":" + z;
+    public static long chunkHash(int x, int z) {
+        return (((long) x) << 32) | (z & 0xffffffffL);
     }
 
-    public static String blockHash(Vector3 block) {
+    public static BlockVector3 blockHash(Vector3 block) {
         return blockHash(block.x, block.y, block.z);
     }
 
-    public static String blockHash(double x, double y, double z) {
-        return (int) x + ":" + (int) y + ":" + (int) z;
+    public static short localBlockHash(double x, double y, double z) {
+        byte hi = (byte) (((int) x & 15) + (((int) z & 15) << 4));
+        byte lo = (byte) y;
+        return (short)( ((hi & 0xFF)<<8) | (lo & 0xFF) );
+    }
+
+    public static Vector3 getBlockXYZ(long chunkHash, short blockHash) {
+        int hi = (byte) (blockHash >>> 8);
+        int lo = (byte) blockHash;
+        int y = lo & 0xFF;
+        int x = (hi & 0xF) + (getHashX(chunkHash) << 4);
+        int z = ((hi >> 4) & 0xF) + (getHashZ(chunkHash) << 4);
+        return new Vector3(x, y, z);
+    }
+
+    public static BlockVector3 blockHash(double x, double y, double z) {
+        return new BlockVector3((int) x, (int) y, (int) z);
     }
 
     public static int chunkBlockHash(int x, int y, int z) {
         return (x << 11) | (z << 7) | y;
     }
 
-    public static Vector3 getBlockXYZ(String hash) {
-        String[] h = hash.split(":");
-        return new Vector3(Integer.valueOf(h[0]), Integer.valueOf(h[1]), Integer.valueOf(h[2]));
+    public static int getHashX(long hash) {
+        return (int) (hash >> 32);
     }
 
-    public static Chunk.Entry getChunkXZ(String hash) {
-        String[] h = hash.split(":");
-        return new Chunk.Entry(Integer.valueOf(h[0]), Integer.valueOf(h[1]));
+    public static int getHashZ(long hash) {
+        return (int) hash;
+    }
+
+    public static Vector3 getBlockXYZ(BlockVector3 hash) {
+        return new Vector3(hash.x, hash.y, hash.z);
+    }
+
+    public static Chunk.Entry getChunkXZ(long hash) {
+        return new Chunk.Entry(getHashX(hash), getHashZ(hash));
     }
 
     public static int generateChunkLoaderId(ChunkLoader loader) {
@@ -491,7 +524,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public Map<Integer, Player> getChunkPlayers(int chunkX, int chunkZ) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        Long index = Level.chunkHash(chunkX, chunkZ);
         if (this.playerLoaders.containsKey(index)) {
             return new HashMap<>(this.playerLoaders.get(index));
         } else {
@@ -500,7 +533,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public ChunkLoader[] getChunkLoaders(int chunkX, int chunkZ) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        Long index = Level.chunkHash(chunkX, chunkZ);
         if (this.chunkLoaders.containsKey(index)) {
             return this.chunkLoaders.get(index).values().stream().toArray(ChunkLoader[]::new);
         } else {
@@ -509,7 +542,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public void addChunkPacket(int chunkX, int chunkZ, DataPacket packet) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        Long index = Level.chunkHash(chunkX, chunkZ);
         if (!this.chunkPackets.containsKey(index)) {
             this.chunkPackets.put(index, new ArrayList<>());
         }
@@ -522,7 +555,7 @@ public class Level implements ChunkManager, Metadatable {
 
     public void registerChunkLoader(ChunkLoader loader, int chunkX, int chunkZ, boolean autoLoad) {
         int hash = loader.getLoaderId();
-        String index = Level.chunkHash(chunkX, chunkZ);
+        Long index = Level.chunkHash(chunkX, chunkZ);
         if (!this.chunkLoaders.containsKey(index)) {
             this.chunkLoaders.put(index, new HashMap<>());
             this.playerLoaders.put(index, new HashMap<>());
@@ -551,7 +584,7 @@ public class Level implements ChunkManager, Metadatable {
 
     public void unregisterChunkLoader(ChunkLoader loader, int chunkX, int chunkZ) {
         int hash = loader.getLoaderId();
-        String index = Level.chunkHash(chunkX, chunkZ);
+        Long index = Level.chunkHash(chunkX, chunkZ);
         if (this.chunkLoaders.containsKey(index) && this.chunkLoaders.get(index).containsKey(hash)) {
             this.chunkLoaders.get(index).remove(hash);
             this.playerLoaders.get(index).remove(hash);
@@ -643,7 +676,9 @@ public class Level implements ChunkManager, Metadatable {
 
         if (this.isThundering()) {
             synchronized (this) {
-                for (FullChunk chunk : this.getChunks().values()) {
+                for (Map.Entry<Long, BaseFullChunk> entry : this.chunks.entrySet()) {
+                    long index = entry.getKey();
+                    BaseFullChunk chunk = entry.getValue();
                     if (rand.nextInt(100000) == 0) {
                         this.updateLCG = this.updateLCG * 3 + 1013904223;
                         int LCG = this.updateLCG >> 2;
@@ -689,10 +724,13 @@ public class Level implements ChunkManager, Metadatable {
 
         TimingsHistory.entityTicks += this.updateEntities.size();
         this.timings.entityTick.startTiming();
-        for (long id : new ArrayList<>(this.updateEntities.keySet())) {
-            Entity entity = this.updateEntities.get(id);
-            if (entity.closed || !entity.onUpdate(currentTick)) {
-                this.updateEntities.remove(id);
+
+        if (!this.updateEntities.isEmpty()) {
+            for (long id : new ArrayList<>(this.updateEntities.keySet())) {
+                Entity entity = this.updateEntities.get(id);
+                if (entity.closed || !entity.onUpdate(currentTick)) {
+                    this.updateEntities.remove(id);
+                }
             }
         }
         this.timings.entityTick.stopTiming();
@@ -714,27 +752,33 @@ public class Level implements ChunkManager, Metadatable {
 
         if (!this.changedBlocks.isEmpty()) {
             if (!this.players.isEmpty()) {
-                for (String index : new ArrayList<>(this.changedBlocks.keySet())) {
-                    Map<String, Vector3> blocks = this.changedBlocks.get(index);
+                for (Map.Entry<Long, SoftReference<Map<Short, Object>>> entry : changedBlocks.entrySet()) {
+                    long index = entry.getKey();
+                    Map<Short, Object> blocks = entry.getValue().get();
                     this.chunkCache.remove(index);
-                    Chunk.Entry chunkEntry = Level.getChunkXZ(index);
-                    int chunkX = chunkEntry.chunkX;
-                    int chunkZ = chunkEntry.chunkZ;
-                    if (blocks.size() > 512) {
+                    int chunkX = Level.getHashX(index);
+                    int chunkZ = Level.getHashZ(index);
+                    if (blocks == null || blocks.size() > MAX_BLOCK_CACHE) {
                         FullChunk chunk = this.getChunk(chunkX, chunkZ);
                         for (Player p : this.getChunkPlayers(chunkX, chunkZ).values()) {
                             p.onChunkChanged(chunk);
                         }
                     } else {
-                        this.sendBlocks(this.getChunkPlayers(chunkX, chunkZ).values().stream().toArray(Player[]::new),
-                                blocks.values().stream().toArray(Vector3[]::new), UpdateBlockPacket.FLAG_ALL);
+                        Collection<Player> toSend = this.getChunkPlayers(chunkX, chunkZ).values();
+                        Player[] playerArray = toSend.toArray(new Player[toSend.size()]);
+                        Vector3[] blocksArray = new Vector3[blocks.size()];
+                        int i = 0;
+                        for (short blockHash : blocks.keySet()) {
+                            blocksArray[i++] = getBlockXYZ(index, blockHash);
+                        }
+                        this.sendBlocks(playerArray, blocksArray, UpdateBlockPacket.FLAG_ALL);
                     }
                 }
             } else {
-                this.chunkCache = new HashMap<>();
+                this.chunkCache.clear();
             }
 
-            this.changedBlocks = new HashMap<>();
+            this.changedBlocks.clear();
         }
 
         this.processChunkRequest();
@@ -743,44 +787,46 @@ public class Level implements ChunkManager, Metadatable {
             this.checkSleep();
         }
 
-        for (String index : this.moveToSend.keySet()) {
-            Chunk.Entry entry = Level.getChunkXZ(index);
+        for (long index : this.moveToSend.keySet()) {
+            int chunkX = getHashX(index);
+            int chunkZ = getHashZ(index);
             for (MoveEntityPacket packet : this.moveToSend.get(index).values()) {
-                this.addChunkPacket(entry.chunkX, entry.chunkZ, packet);
+                this.addChunkPacket(chunkX, chunkZ, packet);
             }
         }
-        this.moveToSend = new HashMap<>();
+        this.moveToSend.clear();
 
-        for (String index : this.motionToSend.keySet()) {
-            Chunk.Entry entry = Level.getChunkXZ(index);
+        for (long index : this.motionToSend.keySet()) {
+            int chunkX = getHashX(index);
+            int chunkZ = getHashZ(index);
             SetEntityMotionPacket pk = new SetEntityMotionPacket();
             pk.entities = this.motionToSend.get(index).values().stream().toArray(SetEntityMotionPacket.Entry[]::new);
-            this.addChunkPacket(entry.chunkX, entry.chunkZ, pk);
+            this.addChunkPacket(chunkX, chunkZ, pk);
         }
 
-        this.motionToSend = new HashMap<>();
+        this.motionToSend.clear();
 
-        for (String index : this.playerMoveToSend.keySet()) {
-            Chunk.Entry entry = Level.getChunkXZ(index);
+        for (long index : this.playerMoveToSend.keySet()) {
+            int chunkX = getHashX(index);
+            int chunkZ = getHashZ(index);
             for (MovePlayerPacket packet : this.playerMoveToSend.get(index).values()) {
-                this.addChunkPacket(entry.chunkX, entry.chunkZ, packet);
+                this.addChunkPacket(chunkX, chunkZ, packet);
             }
         }
-        this.playerMoveToSend = new HashMap<>();
+        this.playerMoveToSend.clear();
 
-        for (String key : this.chunkPackets.keySet()) {
-            Chunk.Entry chunkEntry = Level.getChunkXZ(key);
-            int chunkX = chunkEntry.chunkX;
-            int chunkZ = chunkEntry.chunkZ;
+        for (long index : this.chunkPackets.keySet()) {
+            int chunkX = Level.getHashX(index);
+            int chunkZ = Level.getHashZ(index);
             Player[] chunkPlayers = this.getChunkPlayers(chunkX, chunkZ).values().stream().toArray(Player[]::new);
             if (chunkPlayers.length > 0) {
-                for (DataPacket pk : this.chunkPackets.get(key)) {
+                for (DataPacket pk : this.chunkPackets.get(index)) {
                     Server.broadcastPacket(chunkPlayers, pk);
                 }
             }
         }
 
-        this.chunkPackets = new HashMap<>();
+        this.chunkPackets.clear();
         this.timings.doTick.stopTiming();
     }
 
@@ -848,7 +894,7 @@ public class Level implements ChunkManager, Metadatable {
         List<UpdateBlockPacket> packets = new ArrayList<>();
         UpdateBlockPacket packet = null;
         if (optimizeRebuilds) {
-            Map<String, Boolean> chunks = new HashMap<>();
+            Map<Long, Boolean> chunks = new HashMap<>();
             for (Vector3 b : blocks) {
                 if (b == null) {
                     continue;
@@ -856,7 +902,7 @@ public class Level implements ChunkManager, Metadatable {
                 packet = new UpdateBlockPacket();
                 boolean first = false;
 
-                String index = Level.chunkHash((int) b.x >> 4, (int) b.z >> 4);
+                long index = Level.chunkHash((int) b.x >> 4, (int) b.z >> 4);
                 if (!chunks.containsKey(index)) {
                     chunks.put(index, true);
                     first = true;
@@ -910,15 +956,15 @@ public class Level implements ChunkManager, Metadatable {
 
     public void clearCache(boolean full) {
         if (full) {
-            this.chunkCache = new HashMap<>();
-            this.blockCache = new HashMap<>();
+            this.chunkCache.clear();
+            this.blockCache.clear();
         } else {
             if (this.chunkCache.size() > 2048) {
-                this.chunkCache = new HashMap<>();
+                this.chunkCache.clear();
             }
 
             if (this.blockCache.size() > 2048) {
-                this.blockCache = new HashMap<>();
+                this.blockCache.clear();
             }
         }
     }
@@ -941,13 +987,13 @@ public class Level implements ChunkManager, Metadatable {
             int chunkX = (int) loader.getX() >> 4;
             int chunkZ = (int) loader.getZ() >> 4;
 
-            String index = Level.chunkHash(chunkX, chunkZ);
+            Long index = Level.chunkHash(chunkX, chunkZ);
             int existingLoaders = Math.max(0, this.chunkTickList.containsKey(index) ? this.chunkTickList.get(index) : 0);
             this.chunkTickList.put(index, existingLoaders + 1);
             for (int chunk = 0; chunk < chunksPerLoader; ++chunk) {
                 int dx = new java.util.Random().nextInt(2 * randRange) - randRange;
                 int dz = new java.util.Random().nextInt(2 * randRange) - randRange;
-                String hash = Level.chunkHash(dx + chunkX, dz + chunkZ);
+                long hash = Level.chunkHash(dx + chunkX, dz + chunkZ);
                 if (!this.chunkTickList.containsKey(hash) && this.chunks.containsKey(hash)) {
                     this.chunkTickList.put(hash, -1);
                 }
@@ -956,12 +1002,11 @@ public class Level implements ChunkManager, Metadatable {
 
         int blockTest = 0;
 
-        for (String index : new ArrayList<>(this.chunkTickList.keySet())) {
+        for (Long index : new ArrayList<>(this.chunkTickList.keySet())) {
             int loaders = this.chunkTickList.get(index);
 
-            Chunk.Entry chunkEntry = Level.getChunkXZ(index);
-            int chunkX = chunkEntry.chunkX;
-            int chunkZ = chunkEntry.chunkZ;
+            int chunkX = getHashX(index);
+            int chunkZ = getHashZ(index);
 
             FullChunk chunk;
             if (!this.chunks.containsKey(index) || (chunk = this.getChunk(chunkX, chunkZ, false)) == null) {
@@ -1150,7 +1195,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public void scheduleUpdate(Vector3 pos, int delay) {
-        String index = Level.blockHash((int) pos.x, (int) pos.y, (int) pos.z);
+        BlockVector3 index = Level.blockHash((int) pos.x, (int) pos.y, (int) pos.z);
         if (this.updateQueueIndex.containsKey(index) && this.updateQueueIndex.get(index) <= delay) {
             return;
         }
@@ -1248,6 +1293,31 @@ public class Level implements ChunkManager, Metadatable {
         return collides.stream().toArray(AxisAlignedBB[]::new);
     }
 
+    public boolean hasCollision(Entity entity, AxisAlignedBB bb, boolean entities) {
+        int minX = NukkitMath.floorDouble(bb.minX);
+        int minY = NukkitMath.floorDouble(bb.minY);
+        int minZ = NukkitMath.floorDouble(bb.minZ);
+        int maxX = NukkitMath.ceilDouble(bb.maxX);
+        int maxY = NukkitMath.ceilDouble(bb.maxY);
+        int maxZ = NukkitMath.ceilDouble(bb.maxZ);
+
+        for (int z = minZ; z <= maxZ; ++z) {
+            for (int x = minX; x <= maxX; ++x) {
+                for (int y = minY; y <= maxY; ++y) {
+                    Block block = this.getBlock(this.temporalVector.setComponents(x, y, z));
+                    if (!block.canPassThrough() && block.collidesWithBB(bb)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        if (entities) {
+            return this.getCollidingEntities(bb.grow(0.25f, 0.25f, 0.25f), entity).length > 0;
+        }
+        return false;
+    }
+
     public int getFullLight(Vector3 pos) {
         FullChunk chunk = this.getChunk((int) pos.x >> 4, (int) pos.z >> 4, false);
         int level = 0;
@@ -1273,8 +1343,8 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public Block getBlock(Vector3 pos, boolean cached) {
-        String chunkIndex = Level.chunkHash((int) pos.x >> 4, (int) pos.z >> 4);
-        String index = Level.blockHash((int) pos.x, (int) pos.y, (int) pos.z);
+        long chunkIndex = Level.chunkHash((int) pos.x >> 4, (int) pos.z >> 4);
+        BlockVector3 index = Level.blockHash((int) pos.x, (int) pos.y, (int) pos.z);
         int fullState = 0;
         if (cached && this.blockCache.containsKey(index)) {
             return this.blockCache.get(index);
@@ -1309,8 +1379,8 @@ public class Level implements ChunkManager, Metadatable {
     public void updateBlockLight(int x, int y, int z) {
         Queue<Vector3> lightPropagationQueue = new ConcurrentLinkedQueue<>();
         Queue<Object[]> lightRemovalQueue = new ConcurrentLinkedQueue<>();
-        Map<String, Boolean> visited = new HashMap<>();
-        Map<String, Boolean> removalVisited = new HashMap<>();
+        Map<BlockVector3, Boolean> visited = new HashMap<>();
+        Map<BlockVector3, Boolean> removalVisited = new HashMap<>();
 
         int oldLevel = this.getBlockLightAt(x, y, z);
         int newLevel = Block.light[this.getBlockIdAt(x, y, z)];
@@ -1369,9 +1439,9 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     private void computeRemoveBlockLight(int x, int y, int z, int currentLight, Queue<Object[]> queue,
-                                         Queue<Vector3> spreadQueue, Map<String, Boolean> visited, Map<String, Boolean> spreadVisited) {
+                                         Queue<Vector3> spreadQueue, Map<BlockVector3, Boolean> visited, Map<BlockVector3, Boolean> spreadVisited) {
         int current = this.getBlockLightAt(x, y, z);
-        String index = Level.blockHash(x, y, z);
+        BlockVector3 index = Level.blockHash(x, y, z);
         if (current != 0 && current < currentLight) {
             this.setBlockLightAt(x, y, z, 0);
 
@@ -1390,9 +1460,9 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     private void computeSpreadBlockLight(int x, int y, int z, int currentLight, Queue<Vector3> queue,
-                                         Map<String, Boolean> visited) {
+                                         Map<BlockVector3, Boolean> visited) {
         int current = this.getBlockLightAt(x, y, z);
-        String index = Level.blockHash(x, y, z);
+        BlockVector3 index = Level.blockHash(x, y, z);
 
         if (current < currentLight) {
             this.setBlockLightAt(x, y, z, currentLight);
@@ -1431,19 +1501,14 @@ public class Level implements ChunkManager, Metadatable {
             block.position(position);
             this.blockCache.remove(Level.blockHash((int) position.x, (int) position.y, (int) position.z));
 
-            String index = Level.chunkHash((int) position.x >> 4, (int) position.z >> 4);
+            Long index = Level.chunkHash((int) position.x >> 4, (int) position.z >> 4);
 
             if (direct) {
                 this.sendBlocks(this.getChunkPlayers((int) position.x >> 4, (int) position.z >> 4).values().stream()
                         .toArray(Player[]::new), new Block[]{block}, UpdateBlockPacket.FLAG_ALL_PRIORITY);
                 this.chunkCache.remove(index);
             } else {
-                if (!this.changedBlocks.containsKey(index)) {
-                    this.changedBlocks.put(index, new HashMap<>());
-                }
-
-                this.changedBlocks.get(index).put(Level.blockHash((int) block.x, (int) block.y, (int) block.z),
-                        block.clone());
+                addBlockChange(index, (int) block.x, (int) block.y, (int) block.z);
             }
 
             for (ChunkLoader loader : this.getChunkLoaders((int) position.x >> 4, (int) position.z >> 4)) {
@@ -1469,6 +1534,27 @@ public class Level implements ChunkManager, Metadatable {
         }
 
         return false;
+    }
+
+    private void addBlockChange(int x, int y, int z) {
+        long index = Level.chunkHash(x >> 4, z >> 4);
+        addBlockChange(index, x, y, z);
+    }
+
+    private void addBlockChange(long index, int x, int y, int z) {
+        SoftReference<Map<Short, Object>> current = changedBlocks.get(index);
+        if (current == null) {
+            current = new SoftReference(new HashMap<>());
+            this.changedBlocks.put(index, current);
+        }
+        Map<Short, Object> currentMap = current.get();
+        if (currentMap != changeBlocksFullMap && currentMap != null) {
+            if (currentMap.size() > MAX_BLOCK_CACHE) {
+                this.changedBlocks.put(index, new SoftReference(changeBlocksFullMap));
+            } else {
+                currentMap.put(Level.localBlockHash(x, y, z), changeBlocksPresent);
+            }
+        }
     }
 
     public void dropItem(Vector3 source, Item item) {
@@ -1944,15 +2030,10 @@ public class Level implements ChunkManager, Metadatable {
     public void setBlockIdAt(int x, int y, int z, int id) {
         this.blockCache.remove(Level.blockHash(x, y, z));
         this.getChunk(x >> 4, z >> 4, true).setBlockId(x & 0x0f, y & 0x7f, z & 0x0f, id & 0xff);
-
-        String index = Level.chunkHash(x >> 4, z >> 4);
-        if (!this.changedBlocks.containsKey(index)) {
-            this.changedBlocks.put(index, new HashMap<>());
-        }
-        Vector3 v;
-        this.changedBlocks.get(index).put(Level.blockHash(x, y, z), v = new Vector3(x, y, z));
+        addBlockChange(x, y, z);
+        temporalVector.setComponents(x, y, z);
         for (ChunkLoader loader : this.getChunkLoaders(x >> 4, z >> 4)) {
-            loader.onBlockChanged(v);
+            loader.onBlockChanged(temporalVector);
         }
     }
 
@@ -1975,15 +2056,10 @@ public class Level implements ChunkManager, Metadatable {
     public void setBlockDataAt(int x, int y, int z, int data) {
         this.blockCache.remove(Level.blockHash(x, y, z));
         this.getChunk(x >> 4, z >> 4, true).setBlockData(x & 0x0f, y & 0x7f, z & 0x0f, data & 0x0f);
-
-        String index = Level.chunkHash(x >> 4, z >> 4);
-        if (!this.changedBlocks.containsKey(index)) {
-            this.changedBlocks.put(index, new HashMap<>());
-        }
-        Vector3 v;
-        this.changedBlocks.get(index).put(Level.blockHash(x, y, z), v = new Vector3(x, y, z));
+        addBlockChange(x, y, z);
+        temporalVector.setComponents(x, y, z);
         for (ChunkLoader loader : this.getChunkLoaders(x >> 4, z >> 4)) {
-            loader.onBlockChanged(v);
+            loader.onBlockChanged(temporalVector);
         }
     }
 
@@ -2027,7 +2103,7 @@ public class Level implements ChunkManager, Metadatable {
         this.getChunk(x >> 4, z >> 4, true).setBiomeColor(x & 0x0f, z & 0x0f, R, G, B);
     }
 
-    public Map<String, BaseFullChunk> getChunks() {
+    public Map<Long, BaseFullChunk> getChunks() {
         return chunks;
     }
 
@@ -2037,7 +2113,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public BaseFullChunk getChunk(int chunkX, int chunkZ, boolean create) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        Long index = Level.chunkHash(chunkX, chunkZ);
         if (this.chunks.containsKey(index)) {
             return this.chunks.get(index);
         } else if (this.loadChunk(chunkX, chunkZ, create)) {
@@ -2049,7 +2125,7 @@ public class Level implements ChunkManager, Metadatable {
 
     public void generateChunkCallback(int x, int z, BaseFullChunk chunk) {
         Timings.generationCallbackTimer.startTiming();
-        String index = Level.chunkHash(x, z);
+        Long index = Level.chunkHash(x, z);
         if (this.chunkPopulationQueue.containsKey(index)) {
             FullChunk oldChunk = this.getChunk(x, z, false);
             for (int xx = -1; xx <= 1; ++xx) {
@@ -2096,7 +2172,7 @@ public class Level implements ChunkManager, Metadatable {
             return;
         }
 
-        String index = Level.chunkHash(chunkX, chunkZ);
+        Long index = Level.chunkHash(chunkX, chunkZ);
         FullChunk oldChunk = this.getChunk(chunkX, chunkZ, false);
         if (unload && oldChunk != null) {
             this.unloadChunk(chunkX, chunkZ, false, false);
@@ -2177,7 +2253,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public void requestChunk(int x, int z, Player player) {
-        String index = Level.chunkHash(x, z);
+        Long index = Level.chunkHash(x, z);
         if (!this.chunkSendQueue.containsKey(index)) {
             this.chunkSendQueue.put(index, new HashMap<>());
         }
@@ -2186,7 +2262,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     private void sendChunkFromCache(int x, int z) {
-        String index = Level.chunkHash(x, z);
+        Long index = Level.chunkHash(x, z);
         if (this.chunkSendTasks.containsKey(index)) {
             for (Player player : this.chunkSendQueue.get(index).values()) {
                 if (player.isConnected() && player.usedChunks.containsKey(index)) {
@@ -2202,13 +2278,12 @@ public class Level implements ChunkManager, Metadatable {
     private void processChunkRequest() {
         if (!this.chunkSendQueue.isEmpty()) {
             this.timings.syncChunkSendTimer.startTiming();
-            for (String index : new ArrayList<>(this.chunkSendQueue.keySet())) {
+            for (Long index : new ArrayList<>(this.chunkSendQueue.keySet())) {
                 if (this.chunkSendTasks.containsKey(index)) {
                     continue;
                 }
-                Chunk.Entry chunkEntry = Level.getChunkXZ(index);
-                int x = chunkEntry.chunkX;
-                int z = chunkEntry.chunkZ;
+                int x = getHashX(index);
+                int z = getHashZ(index);
                 this.chunkSendTasks.put(index, true);
                 if (this.chunkCache.containsKey(index)) {
                     this.sendChunkFromCache(x, z);
@@ -2231,7 +2306,7 @@ public class Level implements ChunkManager, Metadatable {
 
     public void chunkRequestCallback(int x, int z, byte[] payload, byte ordering) {
         this.timings.syncChunkSendTimer.startTiming();
-        String index = Level.chunkHash(x, z);
+        Long index = Level.chunkHash(x, z);
 
         if (this.cacheChunks && !this.chunkCache.containsKey(index)) {
             this.chunkCache.put(index, Player.getChunkCacheFromData(x, z, payload, ordering));
@@ -2298,7 +2373,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public boolean isChunkInUse(int x, int z) {
-        String index = Level.chunkHash(x, z);
+        Long index = Level.chunkHash(x, z);
         return this.chunkLoaders.containsKey(index) && !this.chunkLoaders.get(index).isEmpty();
     }
 
@@ -2307,7 +2382,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public boolean loadChunk(int x, int z, boolean generate) {
-        String index = Level.chunkHash(x, z);
+        Long index = Level.chunkHash(x, z);
         if (this.chunks.containsKey(index)) {
             return true;
         }
@@ -2353,7 +2428,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     private void queueUnloadChunk(int x, int z) {
-        String index = Level.chunkHash(x, z);
+        Long index = Level.chunkHash(x, z);
         this.unloadQueue.put(index, System.currentTimeMillis());
         this.chunkTickList.remove(index);
     }
@@ -2395,7 +2470,7 @@ public class Level implements ChunkManager, Metadatable {
 
         this.timings.doChunkUnload.startTiming();
 
-        String index = Level.chunkHash(x, z);
+        Long index = Level.chunkHash(x, z);
 
         BaseFullChunk chunk = this.getChunk(x, z);
 
@@ -2545,7 +2620,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public boolean populateChunk(int x, int z, boolean force) {
-        String index = Level.chunkHash(x, z);
+        Long index = Level.chunkHash(x, z);
         if (this.chunkPopulationQueue.containsKey(index) || this.chunkPopulationQueue.size() >= this.chunkPopulationQueueSize && !force) {
             return false;
         }
@@ -2594,7 +2669,7 @@ public class Level implements ChunkManager, Metadatable {
             return;
         }
 
-        String index = Level.chunkHash(x, z);
+        Long index = Level.chunkHash(x, z);
         if (!this.chunkGenerationQueue.containsKey(index)) {
             Timings.generationTimer.startTiming();
             this.chunkGenerationQueue.put(index, true);
@@ -2627,12 +2702,11 @@ public class Level implements ChunkManager, Metadatable {
             be.close();
         }
 
-        for (String index : this.chunks.keySet()) {
+        for (Long index : this.chunks.keySet()) {
 
             if (!this.unloadQueue.containsKey(index)) {
-                Chunk.Entry chunkEntry = Level.getChunkXZ(index);
-                int X = chunkEntry.chunkX;
-                int Z = chunkEntry.chunkZ;
+                int X = getHashX(index);
+                int Z = getHashZ(index);
                 if (!this.isSpawnChunk(X, Z)) {
                     this.unloadChunkRequest(X, Z, true);
                 }
@@ -2658,12 +2732,11 @@ public class Level implements ChunkManager, Metadatable {
             int maxUnload = 96;
             long now = System.currentTimeMillis();
 
-            for (String index : new ArrayList<>(this.unloadQueue.keySet())) {
+            for (Long index : new ArrayList<>(this.unloadQueue.keySet())) {
                 long time = this.unloadQueue.get(index);
 
-                Chunk.Entry chunkEntry = Level.getChunkXZ(index);
-                int X = chunkEntry.chunkX;
-                int Z = chunkEntry.chunkZ;
+                int X = getHashX(index);
+                int Z = getHashZ(index);
 
                 if (!force) {
                     if (maxUnload <= 0) {
@@ -2702,7 +2775,7 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public void addEntityMotion(int chunkX, int chunkZ, long entityId, double x, double y, double z) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        Long index = Level.chunkHash(chunkX, chunkZ);
         if (!this.motionToSend.containsKey(index)) {
             this.motionToSend.put(index, new HashMap<>());
         }
@@ -2711,7 +2784,7 @@ public class Level implements ChunkManager, Metadatable {
 
     public void addEntityMovement(int chunkX, int chunkZ, long entityId, double x, double y, double z, double yaw,
                                   double pitch, double headYaw) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        Long index = Level.chunkHash(chunkX, chunkZ);
         if (!this.moveToSend.containsKey(index)) {
             this.moveToSend.put(index, new HashMap<>());
         }
@@ -2729,7 +2802,7 @@ public class Level implements ChunkManager, Metadatable {
 
     public void addPlayerMovement(int chunkX, int chunkZ, long entityId, double x, double y, double z, double yaw,
                                   double pitch, boolean onGround) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        Long index = Level.chunkHash(chunkX, chunkZ);
         if (!this.playerMoveToSend.containsKey(index)) {
             this.playerMoveToSend.put(index, new HashMap<>());
         }

--- a/src/main/java/cn/nukkit/level/Location.java
+++ b/src/main/java/cn/nukkit/level/Location.java
@@ -24,6 +24,10 @@ public class Location extends Position {
         this(x, y, 0);
     }
 
+    public Location(double x, double y, double z, Level level) {
+        this(x, y, z, 0, 0, level);
+    }
+
     public Location(double x, double y, double z) {
         this(x, y, z, 0);
     }

--- a/src/main/java/cn/nukkit/level/SimpleChunkManager.java
+++ b/src/main/java/cn/nukkit/level/SimpleChunkManager.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Nukkit Project
  */
 public class SimpleChunkManager implements ChunkManager {
-    protected Map<String, FullChunk> chunks = new ConcurrentHashMap<>();
+    protected Map<Long, FullChunk> chunks = new ConcurrentHashMap<>();
 
     protected final long seed;
 
@@ -56,7 +56,7 @@ public class SimpleChunkManager implements ChunkManager {
 
     @Override
     public BaseFullChunk getChunk(int chunkX, int chunkZ) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        long index = Level.chunkHash(chunkX, chunkZ);
         return this.chunks.containsKey(index) ? (BaseFullChunk) this.chunks.get(index) : null;
     }
 

--- a/src/main/java/cn/nukkit/level/format/LevelProvider.java
+++ b/src/main/java/cn/nukkit/level/format/LevelProvider.java
@@ -83,7 +83,7 @@ public interface LevelProvider {
 
     void setSpawn(Vector3 pos);
 
-    Map<String, ? extends FullChunk> getLoadedChunks();
+    Map<Long, ? extends FullChunk> getLoadedChunks();
 
     void doGarbageCollection();
 

--- a/src/main/java/cn/nukkit/level/format/anvil/Anvil.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/Anvil.java
@@ -28,9 +28,9 @@ import java.util.regex.Pattern;
  */
 public class Anvil extends BaseLevelProvider {
 
-    protected final Map<String, RegionLoader> regions = new HashMap<>();
+    protected final Map<Long, RegionLoader> regions = new HashMap<>();
 
-    protected Map<String, Chunk> chunks = new HashMap<>();
+    protected Map<Long, Chunk> chunks = new HashMap<>();
 
     public Anvil(Level level, String path) throws IOException {
         super(level, path);
@@ -184,7 +184,7 @@ public class Anvil extends BaseLevelProvider {
     }
 
     @Override
-    public Map<String, Chunk> getLoadedChunks() {
+    public Map<Long, Chunk> getLoadedChunks() {
         return this.chunks;
     }
 
@@ -202,10 +202,10 @@ public class Anvil extends BaseLevelProvider {
 
     @Override
     public void doGarbageCollection() {
-        int limit = (int) (System.currentTimeMillis() - 300);
-        for (Map.Entry entry : this.regions.entrySet()) {
-            String index = (String) entry.getKey();
-            RegionLoader region = (RegionLoader) entry.getValue();
+        int limit = (int) (System.currentTimeMillis() - 50);
+        for (Map.Entry<Long, RegionLoader> entry : this.regions.entrySet()) {
+            long index = entry.getKey();
+            RegionLoader region = entry.getValue();
             if (region.lastUsed <= limit) {
                 try {
                     region.close();
@@ -224,7 +224,7 @@ public class Anvil extends BaseLevelProvider {
 
     @Override
     public boolean loadChunk(int chunkX, int chunkZ, boolean create) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        long index = Level.chunkHash(chunkX, chunkZ);
         if (this.chunks.containsKey(index)) {
             return true;
         }
@@ -258,7 +258,7 @@ public class Anvil extends BaseLevelProvider {
 
     @Override
     public boolean unloadChunk(int X, int Z, boolean safe) {
-        String index = Level.chunkHash(X, Z);
+        long index = Level.chunkHash(X, Z);
         Chunk chunk = this.chunks.containsKey(index) ? this.chunks.get(index) : null;
         if (chunk != null && chunk.unload(false, safe)) {
             this.chunks.remove(index);
@@ -279,7 +279,7 @@ public class Anvil extends BaseLevelProvider {
     }
 
     protected RegionLoader getRegion(int x, int z) {
-        String index = Level.chunkHash(x, z);
+        long index = Level.chunkHash(x, z);
         return this.regions.containsKey(index) ? this.regions.get(index) : null;
     }
 
@@ -290,7 +290,7 @@ public class Anvil extends BaseLevelProvider {
 
     @Override
     public Chunk getChunk(int chunkX, int chunkZ, boolean create) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        long index = Level.chunkHash(chunkX, chunkZ);
         if (this.chunks.containsKey(index)) {
             return this.chunks.get(index);
         } else {
@@ -311,7 +311,7 @@ public class Anvil extends BaseLevelProvider {
 
         chunk.setX(chunkX);
         chunk.setZ(chunkZ);
-        String index = Level.chunkHash(chunkX, chunkZ);
+        long index = Level.chunkHash(chunkX, chunkZ);
         this.chunks.put(index, (Chunk) chunk);
     }
 
@@ -340,7 +340,7 @@ public class Anvil extends BaseLevelProvider {
     }
 
     protected void loadRegion(int x, int z) {
-        String index = Level.chunkHash(x, z);
+        long index = Level.chunkHash(x, z);
         if (!this.regions.containsKey(index)) {
             try {
                 this.regions.put(index, new RegionLoader(this, x, z));
@@ -353,7 +353,7 @@ public class Anvil extends BaseLevelProvider {
     @Override
     public void close() {
         this.unloadChunks();
-        for (String index : new ArrayList<>(this.regions.keySet())) {
+        for (long index : new ArrayList<>(this.regions.keySet())) {
             RegionLoader region = this.regions.get(index);
             try {
                 region.close();

--- a/src/main/java/cn/nukkit/level/format/mcregion/McRegion.java
+++ b/src/main/java/cn/nukkit/level/format/mcregion/McRegion.java
@@ -32,9 +32,9 @@ import java.util.regex.Pattern;
  */
 public class McRegion extends BaseLevelProvider {
 
-    protected final Map<String, RegionLoader> regions = new HashMap<>();
+    protected final Map<Long, RegionLoader> regions = new HashMap<>();
 
-    protected Map<String, Chunk> chunks = new HashMap<>();
+    protected Map<Long, Chunk> chunks = new HashMap<>();
 
     public McRegion(Level level, String path) throws IOException {
         super(level, path);
@@ -139,11 +139,17 @@ public class McRegion extends BaseLevelProvider {
             }
         }
 
-        BinaryStream extraData = new BinaryStream();
-        extraData.putLInt(chunk.getBlockExtraDataArray().size());
-        for (Integer key : chunk.getBlockExtraDataArray().keySet()) {
-            extraData.putLInt(key);
-            extraData.putLShort(chunk.getBlockExtraDataArray().get(key));
+        Map<Integer, Integer> extra = chunk.getBlockExtraDataArray();
+        BinaryStream extraData;
+        if (!extra.isEmpty()) {
+            extraData = new BinaryStream();
+            extraData.putLInt(extra.size());
+            for (Map.Entry<Integer, Integer> entry : extra.entrySet()) {
+                extraData.putLInt(entry.getKey());
+                extraData.putLShort(entry.getValue());
+            }
+        } else {
+            extraData = null;
         }
 
         BinaryStream stream = new BinaryStream();
@@ -157,7 +163,9 @@ public class McRegion extends BaseLevelProvider {
         for (int color : chunk.getBiomeColorArray()) {
             stream.put(Binary.writeInt(color));
         }
-        stream.put(extraData.getBuffer());
+        if (extraData != null) {
+            stream.put(extraData.getBuffer());
+        }
         stream.put(tiles);
 
         this.getLevel().chunkRequestCallback(x, z, stream.getBuffer());
@@ -188,7 +196,7 @@ public class McRegion extends BaseLevelProvider {
     }
 
     @Override
-    public Map<String, Chunk> getLoadedChunks() {
+    public Map<Long, Chunk> getLoadedChunks() {
         return this.chunks;
     }
 
@@ -206,10 +214,10 @@ public class McRegion extends BaseLevelProvider {
 
     @Override
     public void doGarbageCollection() {
-        int limit = (int) (System.currentTimeMillis() - 300);
-        for (Map.Entry entry : this.regions.entrySet()) {
-            String index = (String) entry.getKey();
-            RegionLoader region = (RegionLoader) entry.getValue();
+        int limit = (int) (System.currentTimeMillis() - 50);
+        for (Map.Entry<Long, RegionLoader> entry : this.regions.entrySet()) {
+            long index = entry.getKey();
+            RegionLoader region = entry.getValue();
             if (region.lastUsed <= limit) {
                 try {
                     region.close();
@@ -228,7 +236,7 @@ public class McRegion extends BaseLevelProvider {
 
     @Override
     public boolean loadChunk(int chunkX, int chunkZ, boolean create) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        long index = Level.chunkHash(chunkX, chunkZ);
         if (this.chunks.containsKey(index)) {
             return true;
         }
@@ -266,7 +274,7 @@ public class McRegion extends BaseLevelProvider {
 
     @Override
     public boolean unloadChunk(int X, int Z, boolean safe) {
-        String index = Level.chunkHash(X, Z);
+        long index = Level.chunkHash(X, Z);
         Chunk chunk = this.chunks.containsKey(index) ? this.chunks.get(index) : null;
         if (chunk != null && chunk.unload(false, safe)) {
             this.chunks.remove(index);
@@ -287,7 +295,7 @@ public class McRegion extends BaseLevelProvider {
     }
 
     protected RegionLoader getRegion(int x, int z) {
-        String index = Level.chunkHash(x, z);
+        long index = Level.chunkHash(x, z);
         return this.regions.containsKey(index) ? this.regions.get(index) : null;
     }
 
@@ -298,7 +306,7 @@ public class McRegion extends BaseLevelProvider {
 
     @Override
     public Chunk getChunk(int chunkX, int chunkZ, boolean create) {
-        String index = Level.chunkHash(chunkX, chunkZ);
+        long index = Level.chunkHash(chunkX, chunkZ);
         if (this.chunks.containsKey(index)) {
             return this.chunks.get(index);
         } else {
@@ -318,7 +326,7 @@ public class McRegion extends BaseLevelProvider {
         this.loadRegion(regionX, regionZ);
         chunk.setX(chunkX);
         chunk.setZ(chunkZ);
-        String index = Level.chunkHash(chunkX, chunkZ);
+        long index = Level.chunkHash(chunkX, chunkZ);
         if (this.chunks.containsKey(index) && !this.chunks.get(index).equals(chunk)) {
             this.unloadChunk(chunkX, chunkZ, false);
         }
@@ -342,7 +350,7 @@ public class McRegion extends BaseLevelProvider {
     }
 
     protected void loadRegion(int x, int z) {
-        String index = Level.chunkHash(x, z);
+        long index = Level.chunkHash(x, z);
         if (!this.regions.containsKey(index)) {
             this.regions.put(index, new RegionLoader(this, x, z));
         }
@@ -351,7 +359,7 @@ public class McRegion extends BaseLevelProvider {
     @Override
     public void close() {
         this.unloadChunks();
-        for (String index : new ArrayList<>(this.regions.keySet())) {
+        for (long index : new ArrayList<>(this.regions.keySet())) {
             RegionLoader region = this.regions.get(index);
             try {
                 region.close();

--- a/src/main/java/cn/nukkit/math/BlockVector3.java
+++ b/src/main/java/cn/nukkit/math/BlockVector3.java
@@ -1,0 +1,207 @@
+package cn.nukkit.math;
+
+public class BlockVector3 implements Cloneable {
+    public static final int SIDE_DOWN = 0;
+    public static final int SIDE_UP = 1;
+    public static final int SIDE_NORTH = 2;
+    public static final int SIDE_SOUTH = 3;
+    public static final int SIDE_WEST = 4;
+    public static final int SIDE_EAST = 5;
+
+    public int x;
+    public int y;
+    public int z;
+
+    public BlockVector3(int x, int y, int z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    public BlockVector3() {}
+
+    public BlockVector3 setComponents(int x, int y, int z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        return this;
+    }
+
+    public int getX() {
+        return this.x;
+    }
+
+    public int getY() {
+        return this.y;
+    }
+
+    public int getZ() {
+        return this.z;
+    }
+    public Vector3 add(double x) {
+        return this.add(x, 0, 0);
+    }
+
+    public Vector3 add(double x, double y) {
+        return this.add(x, y, 0);
+    }
+
+    public Vector3 add(double x, double y, double z) {
+        return new Vector3(this.x + x, this.y + y, this.z + z);
+    }
+
+    public Vector3 add(Vector3 x) {
+        return new Vector3(this.x + x.getX(), this.y + x.getY(), this.z + x.getZ());
+    }
+
+    public Vector3 subtract(double x) {
+        return this.subtract(x, 0, 0);
+    }
+
+    public Vector3 subtract(double x, double y) {
+        return this.subtract(x, y, 0);
+    }
+
+    public Vector3 subtract(double x, double y, double z) {
+        return this.add(-x, -y, -z);
+    }
+
+    public Vector3 subtract(Vector3 x) {
+        return this.add(-x.getX(), -x.getY(), -x.getZ());
+    }
+
+    public BlockVector3 add(int x) {
+        return this.add(x, 0, 0);
+    }
+
+    public BlockVector3 add(int x, int y) {
+        return this.add(x, y, 0);
+    }
+
+    public BlockVector3 add(int x, int y, int z) {
+        return new BlockVector3(this.x + x, this.y + y, this.z + z);
+    }
+
+    public BlockVector3 add(BlockVector3 x) {
+        return new BlockVector3(this.x + x.getX(), this.y + x.getY(), this.z + x.getZ());
+    }
+
+    public BlockVector3 subtract() {
+        return this.subtract(0, 0, 0);
+    }
+
+    public BlockVector3 subtract(int x) {
+        return this.subtract(x, 0, 0);
+    }
+
+    public BlockVector3 subtract(int x, int y) {
+        return this.subtract(x, y, 0);
+    }
+
+    public BlockVector3 subtract(int x, int y, int z) {
+        return this.add(-x, -y, -z);
+    }
+
+    public BlockVector3 subtract(BlockVector3 x) {
+        return this.add(-x.getX(), -x.getY(), -x.getZ());
+    }
+
+    public BlockVector3 multiply(int number) {
+        return new BlockVector3(this.x * number, this.y * number, this.z * number);
+    }
+
+    public BlockVector3 divide(int number) {
+        return new BlockVector3(this.x / number, this.y / number, this.z / number);
+    }
+
+    public BlockVector3 getSide(int side) {
+        return this.getSide(side, 1);
+    }
+
+    public BlockVector3 getSide(int side, int step) {
+        switch (side) {
+            case BlockVector3.SIDE_DOWN:
+                return new BlockVector3(this.x, this.y - step, this.z);
+            case BlockVector3.SIDE_UP:
+                return new BlockVector3(this.x, this.y + step, this.z);
+            case BlockVector3.SIDE_NORTH:
+                return new BlockVector3(this.x, this.y, this.z - step);
+            case BlockVector3.SIDE_SOUTH:
+                return new BlockVector3(this.x, this.y, this.z + step);
+            case BlockVector3.SIDE_WEST:
+                return new BlockVector3(this.x - step, this.y, this.z);
+            case BlockVector3.SIDE_EAST:
+                return new BlockVector3(this.x + step, this.y, this.z);
+            default:
+                return this;
+        }
+    }
+
+    public static int getOppositeSide(int side) {
+        switch (side) {
+            case BlockVector3.SIDE_DOWN:
+                return BlockVector3.SIDE_UP;
+            case BlockVector3.SIDE_UP:
+                return BlockVector3.SIDE_DOWN;
+            case BlockVector3.SIDE_NORTH:
+                return BlockVector3.SIDE_SOUTH;
+            case BlockVector3.SIDE_SOUTH:
+                return BlockVector3.SIDE_NORTH;
+            case BlockVector3.SIDE_WEST:
+                return BlockVector3.SIDE_EAST;
+            case BlockVector3.SIDE_EAST:
+                return BlockVector3.SIDE_WEST;
+            default:
+                return -1;
+        }
+    }
+
+    public double distance(Vector3 pos) {
+        return Math.sqrt(this.distanceSquared(pos));
+    }
+
+    public double distance(BlockVector3 pos) {
+        return Math.sqrt(this.distanceSquared(pos));
+    }
+
+    public double distanceSquared(Vector3 pos) {
+        return distanceSquared(pos.x, pos.y, pos.z);
+    }
+
+    public double distanceSquared(BlockVector3 pos) {
+        return distanceSquared(pos.x, pos.y, pos.z);
+    }
+
+    public double distanceSquared(double x, double y, double z) {
+        return Math.pow(this.x - x, 2) + Math.pow(this.y - y, 2) + Math.pow(this.z - z, 2);
+    }
+
+    @Override
+    public boolean equals(Object ob) {
+        if (ob == null) return false;
+        if (ob == this) return true;
+
+        if (!(ob instanceof BlockVector3)) return false;
+
+        return this.x == ((BlockVector3)ob).x && this.z == ((BlockVector3)ob).z;
+    }
+
+    @Override
+    public final int hashCode() {
+        return (x ^ (z << 12)) ^ (y << 24);
+    }
+
+    @Override
+    public String toString() {
+        return "BlockPosition(level=" + ",x=" + this.x + ",y=" + this.y + ",z=" + this.z + ")";
+    }
+
+    @Override
+    public BlockVector3 clone() {
+        try {
+            return (BlockVector3) super.clone();
+        } catch (CloneNotSupportedException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/raknet/server/SessionManager.java
+++ b/src/main/java/cn/nukkit/raknet/server/SessionManager.java
@@ -75,7 +75,6 @@ public class SessionManager {
         while (!this.shutdown) {
             long start = System.currentTimeMillis();
             int max = 5000;
-            this.socket.clearPacketQueue();
             while (max > 0) {
                 try {
                     if (!this.receivePacket()) {

--- a/src/main/java/cn/nukkit/utils/MainLogger.java
+++ b/src/main/java/cn/nukkit/utils/MainLogger.java
@@ -204,7 +204,7 @@ public class MainLogger extends ThreadedLogger {
     @Override
     public void run() {
         this.shutdown = false;
-        while (!this.shutdown) {
+        while (!this.shutdown && Nukkit.DEBUG > 0) {
             while (this.logStream.length() > 0) {
                 String chunk = this.logStream;
                 this.logStream = "";


### PR DESCRIPTION
Fixes Nukkit not handling any packets
Use Long/BlockVector3 instead of strings for maps
Reduce cache size significantly by not storing redundant data
Reduce login time significantly by reducing min chunk radius
Reduce chunk load by avoiding processing extra data
Reduce memory usage by storing cache in weak map
Reduce memory usage by unloading chunks more often
Reduce memory usage by using soft reference for some block updates
- If gc'd it will send a chunk update instead (less memory usage)

Optimize collision checks
Optimize various things by reusing objects and avoiding unnecesary
creation
Add debug level 0 = does not log to file