### PR TITLE
Better time ticking and sync

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -102,8 +102,6 @@ public class Level implements ChunkManager, Metadatable {
 
     private boolean cacheChunks = false;
 
-    private int sendTimeTicker = 0;
-
     private final Server server;
 
     private final int levelId;
@@ -606,7 +604,7 @@ public class Level implements ChunkManager, Metadatable {
 
     public void checkTime() {
         if (!this.stopTime) {
-            this.time += 1;
+            this.time += tickRate;
         }
     }
 
@@ -645,11 +643,6 @@ public class Level implements ChunkManager, Metadatable {
         this.timings.doTick.startTiming();
 
         this.checkTime();
-
-        if (++this.sendTimeTicker == 200) {
-            this.sendTime();
-            this.sendTimeTicker = 0;
-        }
 
         // Tick Weather
         this.rainTime--;


### PR DESCRIPTION
* Remove unnecessary SetTimePacket spam

This is handled automatically client-side, as long as it is calculated
correctly server side there is no issue (unless the server hits a spot
of bad lag)

* Better client/server time sync when lagging

From
https://github.com/pmmp/PocketMine-MP/commit/e9f2bf0085e89955ec6eb7ff9b07b004e8153e2c