### PR TITLE
Fix client crash (converted worlds)

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -282,7 +282,7 @@ public abstract class Entity extends Location implements Metadatable {
         this.fallDistance = this.namedTag.getFloat("FallDistance");
         this.highestPosition = this.y + this.namedTag.getFloat("FallDistance");
 
-        if (!this.namedTag.contains("Fire")) {
+        if (!this.namedTag.contains("Fire") || this.namedTag.getShort("Fire") > 32767) {
             this.namedTag.putShort("Fire", 0);
         }
         this.fireTicks = this.namedTag.getShort("Fire");


### PR DESCRIPTION
From
https://github.com/ClearSkyTeam/ClearSky/commit/b80b2f9c36a185106a6de1e255f396d7a0d71d0f

Okay, this one I don't know how to reproduce, but it seems related to LevelDB map importing.