### PR TITLE
Network: Do not attempt to decode further for non-accepted protocols

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/LoginPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/LoginPacket.java
@@ -37,6 +37,9 @@ public class LoginPacket extends DataPacket {
     @Override
     public void decode() {
         this.protocol = this.getInt();
+        if (this.protocol != ProtocolInfo.CURRENT_PROTOCOL) {
+        	return; // Do not attempt to decode for non-accepted protocols
+        }
         byte[] str;
         try {
             str = Zlib.inflate(this.get(this.getInt()), 64*1024*1024);


### PR DESCRIPTION
Prevents 0.16 players causing error spam on 0.15 servers

From
https://github.com/ClearSkyTeam/ClearSky/commit/f704de6e9589a85cb47d001b252e28fe0a9859eb