### PR TITLE
Fix null items causing chunk corruption or failure on save.

### DIFF
--- a/src/main/java/cn/nukkit/entity/item/EntityItem.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityItem.java
@@ -181,16 +181,18 @@ public class EntityItem extends Entity {
     @Override
     public void saveNBT() {
         super.saveNBT();
-        this.namedTag.putCompound("Item", NBTIO.putItemHelper(this.item));
-        this.namedTag.putShort("Health", this.getHealth());
-        this.namedTag.putShort("Age", this.age);
-        this.namedTag.putShort("PickupDelay", this.pickupDelay);
-        if (this.owner != null) {
-            this.namedTag.putString("Owner", this.owner);
-        }
-
-        if (this.thrower != null) {
-            this.namedTag.putString("Thrower", this.thrower);
+        if (this.item != null) { // Yes, a item can be null... I don't know what causes this, but it can happen.
+	        this.namedTag.putCompound("Item", NBTIO.putItemHelper(this.item));
+	        this.namedTag.putShort("Health", this.getHealth());
+	        this.namedTag.putShort("Age", this.age);
+	        this.namedTag.putShort("PickupDelay", this.pickupDelay);
+	        if (this.owner != null) {
+	            this.namedTag.putString("Owner", this.owner);
+	        }
+	
+	        if (this.thrower != null) {
+	            this.namedTag.putString("Thrower", this.thrower);
+	        }
         }
     }
 


### PR DESCRIPTION
Fixes #1072

Bug stacktrace:
```
2016-10-4 12:12:59 [INFO] Descarregando mundo "WarpVIP"
2016-10-4 12:12:59 [INFO] Descarregando mundo "FightArena"
2016-10-4 12:12:59 [INFO] Descarregando mundo "CoisasInuteis"
2016-10-4 12:12:59 [INFO] Descarregando mundo "world"
2016-10-4 12:12:59 [ALERT] java.lang.RuntimeException: java.lang.RuntimeException: java.lang.NullPointerException
	at cn.nukkit.level.Level.saveChunks(Level.java:1122)
	at cn.nukkit.level.Level.save(Level.java:1105)
	at cn.nukkit.level.Level.save(Level.java:1089)
	at cn.nukkit.level.Level.close(Level.java:399)
	at cn.nukkit.level.Level.unload(Level.java:521)
	at cn.nukkit.Server.unloadLevel(Server.java:1541)
	at cn.nukkit.Server.forceShutdown(Server.java:723)
	at cn.nukkit.Server.start(Server.java:770)
	at cn.nukkit.Server.<init>(Server.java:460)
	at cn.nukkit.Nukkit.main(Nukkit.java:65)
Caused by: java.lang.RuntimeException: java.lang.NullPointerException
	at cn.nukkit.level.format.anvil.Anvil.saveChunk(Anvil.java:276)
	at cn.nukkit.level.Level.saveChunks(Level.java:1118)
	... 9 more
Caused by: java.lang.NullPointerException
	at cn.nukkit.nbt.NBTIO.putItemHelper(NBTIO.java:30)
	at cn.nukkit.nbt.NBTIO.putItemHelper(NBTIO.java:25)
	at cn.nukkit.entity.item.EntityItem.saveNBT(EntityItem.java:185)
	at cn.nukkit.level.format.anvil.Chunk.toBinary(Chunk.java:325)
	at cn.nukkit.level.format.anvil.RegionLoader.writeChunk(RegionLoader.java:143)
	at cn.nukkit.level.format.anvil.Anvil.saveChunk(Anvil.java:274)
	... 10 more

2016-10-4 12:12:59 [EMERGENCY] Exception happened while shutting down, exit the process
2016-10-4 12:12:59 [EMERGENCY] RakNet crashed!
```

This pull request checks if the item is not null before writing the item NBT to the chunk file.

While this is a very specific issue (that I still don't know what causes it, but it happens on my PC imported map) it would be better if it was fixed, because this can cause world save failure on shutdown and chunk corruption.