### PR TITLE
Fix "argument type mismatch" when using EntityDamageByEntityEvent

### DIFF
--- a/src/main/java/cn/nukkit/plugin/MethodEventExecutor.java
+++ b/src/main/java/cn/nukkit/plugin/MethodEventExecutor.java
@@ -20,16 +20,16 @@ public class MethodEventExecutor implements EventExecutor {
     }
 
     @SuppressWarnings("unchecked")
-	@Override
+    @Override
     public void execute(Listener listener, Event event) throws EventException {
         try {
-        	Class<Event>[] params = (Class<Event>[]) method.getParameterTypes();
-        	for (Class<Event> param : params) {
-        		if (param.isAssignableFrom(event.getClass())) {
-        			method.invoke(listener, event);
-        			break;
-        		}
-        	}
+            Class<Event>[] params = (Class<Event>[]) method.getParameterTypes();
+            for (Class<Event> param : params) {
+                if (param.isAssignableFrom(event.getClass())) {
+                    method.invoke(listener, event);
+                    break;
+                }
+            }
         } catch (InvocationTargetException ex) {
             throw new EventException(ex.getCause());
         } catch (Throwable t) {

--- a/src/main/java/cn/nukkit/plugin/MethodEventExecutor.java
+++ b/src/main/java/cn/nukkit/plugin/MethodEventExecutor.java
@@ -19,10 +19,17 @@ public class MethodEventExecutor implements EventExecutor {
         this.method = method;
     }
 
-    @Override
+    @SuppressWarnings("unchecked")
+	@Override
     public void execute(Listener listener, Event event) throws EventException {
         try {
-            method.invoke(listener, event);
+        	Class<Event>[] params = (Class<Event>[]) method.getParameterTypes();
+        	for (Class<Event> param : params) {
+        		if (param.isAssignableFrom(event.getClass())) {
+        			method.invoke(listener, event);
+        			break;
+        		}
+        	}
         } catch (InvocationTargetException ex) {
             throw new EventException(ex.getCause());
         } catch (Throwable t) {


### PR DESCRIPTION
Finally we don't need to use "EntityDamageEvent" and then casting to
"EntityDamageByEntityEvent" just to get the damager!

Fixes #489