### PR TITLE
0.15.10

### DIFF
--- a/src/main/java/cn/nukkit/Nukkit.java
+++ b/src/main/java/cn/nukkit/Nukkit.java
@@ -26,8 +26,8 @@ public class Nukkit {
     public final static String VERSION = "1.0dev";
     public final static String API_VERSION = "1.0.0";
     public final static String CODENAME = "蘋果(Apple)派(Pie)";
-    public final static String MINECRAFT_VERSION = "v0.15.9 alpha";
-    public final static String MINECRAFT_VERSION_NETWORK = "0.15.9";
+    public final static String MINECRAFT_VERSION = "v0.15.10 alpha";
+    public final static String MINECRAFT_VERSION_NETWORK = "0.15.10";
 
     public final static String PATH = System.getProperty("user.dir") + "/";
     public final static String DATA_PATH = System.getProperty("user.dir") + "/";

--- a/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
+++ b/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
@@ -9,7 +9,7 @@ public interface ProtocolInfo {
     /**
      * Actual Minecraft: PE protocol version
      */
-    byte CURRENT_PROTOCOL = 83;
+    byte CURRENT_PROTOCOL = 84;
 
     byte LOGIN_PACKET = (byte) 0x01;
     byte PLAY_STATUS_PACKET = (byte) 0x02;


### PR DESCRIPTION
Because Mojang loves bumping the protocol number on a update that only adds NEW SKINS.

Because skins interfers a lot on the networking part of MCPE, right? 😋 