### PR TITLE
Fix bow cannot be shot after sneaking/sprinting

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1741,6 +1741,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 return;
             }
 
+            packetswitch:
             switch (packet.pid()) {
                 case ProtocolInfo.LOGIN_PACKET:
                     if (this.loggedIn) {
@@ -2335,7 +2336,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             } else {
                                 this.setSprinting(true);
                             }
-                            break;
+                            break packetswitch;
 
                         case PlayerActionPacket.ACTION_STOP_SPRINT:
                             playerToggleSprintEvent = new PlayerToggleSprintEvent(this, false);
@@ -2345,7 +2346,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             } else {
                                 this.setSprinting(false);
                             }
-                            break;
+                            break packetswitch;
 
                         case PlayerActionPacket.ACTION_START_SNEAK:
                             PlayerToggleSneakEvent playerToggleSneakEvent = new PlayerToggleSneakEvent(this, true);
@@ -2355,7 +2356,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             } else {
                                 this.setSneaking(true);
                             }
-                            break;
+                            break packetswitch;
 
                         case PlayerActionPacket.ACTION_STOP_SNEAK:
                             playerToggleSneakEvent = new PlayerToggleSneakEvent(this, false);
@@ -2365,7 +2366,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             } else {
                                 this.setSneaking(false);
                             }
-                            break;
+                            break packetswitch;
                     }
 
                     this.startAction = -1;


### PR DESCRIPTION
From Genisys
https://github.com/iTXTech/Genisys/commit/dea6ecc73059bd9dd2ee4e59e5bfa16933250eb4

(Also, I always test my modifications (except those that I can't reproduce) before creating a pull request)

This has a issue because the stop/start sneak/sprint changes the player data flag to "No Action" so the server thinks we aren't pulling a bow anymore.

How to replicate:
1. Get a bow
2. Pull the bow but don't release
3. Sprint or sneak
4. Release the bow

The bow won't release a arrow, this fix changes the break to break the switch statement instead of breaking the current case.