### PR TITLE
"Fix" ClassCastException when using EntityDamageByEntityEvent

### DIFF
--- a/src/main/java/cn/nukkit/plugin/MethodEventExecutor.java
+++ b/src/main/java/cn/nukkit/plugin/MethodEventExecutor.java
@@ -32,6 +32,8 @@ public class MethodEventExecutor implements EventExecutor {
             }
         } catch (InvocationTargetException ex) {
             throw new EventException(ex.getCause());
+        } catch (ClassCastException ex) {
+            // We are going to ignore ClassCastException because EntityDamageEvent can't be cast to EntityDamageByEntityEvent
         } catch (Throwable t) {
             throw new EventException(t);
         }


### PR DESCRIPTION
This isn't a fancy fix, but I also have no idea why it thinks it should invoke EntityDamageEvent on a EntityDamageByEntityEvent. Probably later I will take a better look, but for now, this should work.