### PR TITLE
Add '-' as accepted username character

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1794,7 +1794,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         if ((c >= 'a' && c <= 'z') ||
                                 (c >= 'A' && c <= 'Z') ||
                                 (c >= '0' && c <= '9') ||
-                                c == '_' || c == ' '
+                                c == '_' || c == ' ' || c == '-'
                                 ) {
                             continue;
                         }


### PR DESCRIPTION
Someone from iOS legitly tried to join with this character in her name. Lets accept it.
Android doesn't seem to accept it, but other characters are (like euro sign). Needs some investigation.