### PR TITLE
Change fallDistance to 0.75 instead of 1, fixes wrong crop trampling behavior.

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1023,7 +1023,7 @@ public abstract class Entity extends Location implements Metadatable {
             this.attack(ev);
         }
 
-        if (fallDistance > 1) {
+        if (fallDistance > 0.75) {
             Block down = this.level.getBlock(this.temporalVector.setComponents(getFloorX(), getFloorY() - 1, getFloorZ()));
 
             if (down.getId() == Item.FARMLAND) {


### PR DESCRIPTION
> Farmland can now only be trampled if the player jumps onto it; walking no longer affects it. Animals, villagers, and other mobs can similarly trample farmland by jumping on it, but not by walking.

However the trample crop checks if the fallDistance is bigger than 1, but a player jump always return ~0.753

This changes the check so crop trampling behavior works as expected, instead of triggering only when you jump higher than 1 block. (Unless if I'm wrong and the default MCPE behavior is like that)
