### PR TITLE
Add BlockFormEvent when a obsidian or cobblestone is generated from liquid

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -464,7 +464,7 @@ public abstract class BlockLiquid extends BlockTransparent {
                     BlockFormEvent ev = new BlockFormEvent(this, newState);
                     this.getLevel().getServer().getPluginManager().callEvent(ev);
                     if (!ev.isCancelled()) {
-                        this.getLevel().setBlock(this, new BlockObsidian(), true);
+                        this.getLevel().setBlock(this, newState, true);
                     }
                 } else if (this.getDamage() <= 4) {
                     Block newState = new BlockObsidian();

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -1,6 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.entity.Entity;
+import cn.nukkit.event.block.BlockFormEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.particle.SmokeParticle;
@@ -457,9 +458,17 @@ public abstract class BlockLiquid extends BlockTransparent {
 
             if (colliding) {
                 if (this.getDamage() == 0) {
-                    this.getLevel().setBlock(this, new BlockObsidian(), true);
+                    BlockFormEvent ev = new BlockFormEvent(this, new BlockObsidian());
+                    this.getLevel().getServer().getPluginManager().callEvent(ev);
+                    if (!ev.isCancelled()) {
+                        this.getLevel().setBlock(this, new BlockObsidian(), true);
+                    }
                 } else if (this.getDamage() <= 4) {
-                    this.getLevel().setBlock(this, new BlockCobblestone(), true);
+                    BlockFormEvent ev = new BlockFormEvent(this, new BlockCobblestone());
+                    this.getLevel().getServer().getPluginManager().callEvent(ev);
+                    if (!ev.isCancelled()) {
+                        this.getLevel().setBlock(this, new BlockCobblestone(), true);
+                    }
                 }
 
                 this.triggerLavaMixEffects(this);

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -458,16 +458,21 @@ public abstract class BlockLiquid extends BlockTransparent {
 
             if (colliding) {
                 if (this.getDamage() == 0) {
-                    BlockFormEvent ev = new BlockFormEvent(this, new BlockObsidian());
+                    Block newState = new BlockObsidian();
+                    newState.setComponents(this.getX(), this.getY(), this.getZ());
+                    newState.setLevel(this.getLevel());
+                    BlockFormEvent ev = new BlockFormEvent(this, newState);
                     this.getLevel().getServer().getPluginManager().callEvent(ev);
                     if (!ev.isCancelled()) {
                         this.getLevel().setBlock(this, new BlockObsidian(), true);
                     }
                 } else if (this.getDamage() <= 4) {
-                    BlockFormEvent ev = new BlockFormEvent(this, new BlockCobblestone());
-                    this.getLevel().getServer().getPluginManager().callEvent(ev);
+                    Block newState = new BlockObsidian();
+                    newState.setComponents(this.getX(), this.getY(), this.getZ());
+                    newState.setLevel(this.getLevel());
+                    BlockFormEvent ev = new BlockFormEvent(this, newState);
                     if (!ev.isCancelled()) {
-                        this.getLevel().setBlock(this, new BlockCobblestone(), true);
+                        this.getLevel().setBlock(this, newState, true);
                     }
                 }
 


### PR DESCRIPTION
Something @imjack wanted and I thought it was a good idea to implement to Nukkit's API.

**Note:** Bukkit doesn't use BlockFormEvent for Obsidian/Cobblestone generated from liquids, however Nukkit doesn't have a BlockFromToEvent, so I used BlockFormEvent, if using BlockFromToEvent is better, then ask that I will change the code.