### PR TITLE
Fix packet sending

### DIFF
--- a/src/main/java/cn/nukkit/utils/Binary.java
+++ b/src/main/java/cn/nukkit/utils/Binary.java
@@ -398,8 +398,9 @@ public class Binary {
     }
 
     public static byte[][] splitBytes(byte[] bytes, int chunkSize) {
-        byte[][] splits = new byte[1024][chunkSize];
+        byte[][] splits = new byte[(bytes.length + chunkSize - 1) / chunkSize][chunkSize];
         int chunks = 0;
+
         for (int i = 0; i < bytes.length; i += chunkSize) {
             if ((bytes.length - i) > chunkSize) {
                 splits[chunks] = Arrays.copyOfRange(bytes, i, i + chunkSize);
@@ -408,8 +409,6 @@ public class Binary {
             }
             chunks++;
         }
-
-        splits = Arrays.copyOf(splits, chunks);
 
         return splits;
     }


### PR DESCRIPTION
Not sure why batched packets were arbitrarily limited to 1024. It crashes the server with this sometimes:

> java.lang.ArrayIndexOutOfBoundsException: 1024
 at cn.nukkit.utils.Binary.splitBytes(Binary.java:405)
 at cn.nukkit.raknet.server.Session.addEncapsulatedToQueue(Session.java:267)
 at cn.nukkit.raknet.server.SessionManager.receiveStream(SessionManager.java:332)
 at cn.nukkit.raknet.server.SessionManager.tickProcessor(SessionManager.java:91)
 at cn.nukkit.raknet.server.SessionManager.run(SessionManager.java:70)
 at cn.nukkit.raknet.server.SessionManager.<init>(SessionManager.java:58)
 at cn.nukkit.raknet.server.RakNetServer.run(RakNetServer.java:101)

For context, that's about 18 chunks
