### PR TITLE
Change kick API

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -69,7 +69,6 @@ import cn.nukkit.timings.Timings;
 import cn.nukkit.utils.Binary;
 import cn.nukkit.utils.TextFormat;
 import cn.nukkit.utils.Zlib;
-
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.*;
@@ -225,7 +224,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     public void setBanned(boolean value) {
         if (value) {
             this.server.getNameBans().addBan(this.getName(), null, null, null);
-            this.kick("You have been banned");
+            this.kick(PlayerKickEvent.Reason.NAME_BANNED, "Banned by admin");
         } else {
             this.server.getNameBans().remove(this.getName());
         }
@@ -1445,7 +1444,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             if (this.inAirTicks < 100) {
                                 //this.sendSettings();
                                 this.setMotion(new Vector3(0, expectedVelocity, 0));
-                            } else if (this.kick("Flying is not enabled on this server")) {
+                            } else if (this.kick(PlayerKickEvent.Reason.FLYING_DISABLED, "Flying is not enabled on this server")) {
                                 return false;
                             }
                         }
@@ -1532,12 +1531,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
     protected void processLogin() {
         if (!this.server.isWhitelisted((this.getName()).toLowerCase())) {
-            this.close(this.getLeaveMessage(), "Server is white-listed");
+            this.kick(PlayerKickEvent.Reason.NOT_WHITELISTED, "Server is white-listed");
 
             return;
-        } else if (this.server.getNameBans().isBanned(this.getName().toLowerCase()) || this.server.getIPBans().isBanned(this.getAddress())) {
-            this.close(this.getLeaveMessage(), "You are banned");
-
+        } else if (this.server.getNameBans().isBanned(this.getName().toLowerCase())) {
+            this.kick(PlayerKickEvent.Reason.NAME_BANNED, "You are banned");
+            return;
+        } else if (this.server.getIPBans().isBanned(this.getAddress())) {
+            this.kick(PlayerKickEvent.Reason.IP_BANNED, "You are banned");
             return;
         }
 
@@ -1549,16 +1550,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         }
 
         for (Player p : new ArrayList<>(this.server.getOnlinePlayers().values())) {
-            if (p != this && p.getName() != null && this.getName() != null && Objects.equals(p.getName().toLowerCase(), this.getName().toLowerCase())) {
-                if (!p.kick("logged in from another location")) {
-                    this.close(this.getLeaveMessage(), "Logged in from another location");
-
+            if (p != this && p.getName() != null && p.getName().equalsIgnoreCase(this.getName())) {
+                if (!p.kick(PlayerKickEvent.Reason.NEW_CONNECTION, "logged in from another location")) {
+                    this.close(this.getLeaveMessage(), "Already connected");
                     return;
                 }
             } else if (p.loggedIn && this.getUniqueId().equals(p.getUniqueId())) {
-                if (!p.kick("logged in from another location")) {
-                    this.close(this.getLeaveMessage(), "Logged in from another location");
-
+                if (!p.kick(PlayerKickEvent.Reason.NEW_CONNECTION, "logged in from another location")) {
+                    this.close(this.getLeaveMessage(), "Already connected");
                     return;
                 }
             }
@@ -1784,7 +1783,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     this.iusername = this.username.toLowerCase();
                     this.setDataProperty(new StringEntityData(DATA_NAMETAG, this.username), false);
 
-                    if (this.server.getOnlinePlayers().size() >= this.server.getMaxPlayers() && this.kick("disconnectionScreen.serverFull", false)) {
+                    if (this.server.getOnlinePlayers().size() >= this.server.getMaxPlayers() && this.kick(PlayerKickEvent.Reason.SERVER_FULL, "disconnectionScreen.serverFull", false)) {
                         break;
                     }
 
@@ -1822,9 +1821,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     if (!loginPacket.skin.isValid()) {
                         this.close("", "disconnectionScreen.invalidSkin");
                         break;
+                    } else {
+                        this.setSkin(loginPacket.getSkin());
                     }
-
-                    this.setSkin(loginPacket.getSkin());
 
                     PlayerPreLoginEvent playerPreLoginEvent;
                     this.server.getPluginManager().callEvent(playerPreLoginEvent = new PlayerPreLoginEvent(this, "Plugin reason"));
@@ -2442,7 +2441,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             cancelled = true;
                         }
                         if (targetEntity instanceof EntityItem || targetEntity instanceof EntityArrow) {
-                            this.kick("Attempting to attack an invalid entity");
+                            this.kick(PlayerKickEvent.Reason.INVALID_PVE, "Attempting to attack an invalid entity");
                             this.server.getLogger().warning(this.getServer().getLanguage().translateString("nukkit.player.invalidEntity", this.getName()));
                             break;
                         }
@@ -3162,11 +3161,27 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         return this.kick("");
     }
 
+    public boolean kick(String reason, boolean isAdmin) {
+        return this.kick(PlayerKickEvent.Reason.UNKNOWN, reason, isAdmin);
+    }
+
     public boolean kick(String reason) {
+        return kick(PlayerKickEvent.Reason.UNKNOWN, reason);
+    }
+
+    public boolean kick(PlayerKickEvent.Reason reason) {
         return this.kick(reason, true);
     }
 
-    public boolean kick(String reason, boolean isAdmin) {
+    public boolean kick(PlayerKickEvent.Reason reason, String reasonString) {
+        return this.kick(reason, reasonString, true);
+    }
+
+    public boolean kick(PlayerKickEvent.Reason reason, boolean isAdmin) {
+        return this.kick(reason, reason.toString(), isAdmin);
+    }
+
+    public boolean kick(PlayerKickEvent.Reason reason, String reasonString, boolean isAdmin) {
         PlayerKickEvent ev;
         this.server.getPluginManager().callEvent(ev = new PlayerKickEvent(this, reason, this.getLeaveMessage()));
         if (!ev.isCancelled()) {
@@ -3175,13 +3190,13 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 if (!this.isBanned()) {
                     message = "Kicked by admin." + (!"".equals(reason) ? " Reason: " + reason : "");
                 } else {
-                    message = reason;
+                    message = reasonString;
                 }
             } else {
                 if ("".equals(reason)) {
                     message = "disconnectionScreen.noReason";
                 } else {
-                    message = reason;
+                    message = reasonString;
                 }
             }
 

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -16,6 +16,7 @@ import cn.nukkit.entity.weather.EntityLightning;
 import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.level.LevelInitEvent;
 import cn.nukkit.event.level.LevelLoadEvent;
+import cn.nukkit.event.player.PlayerKickEvent;
 import cn.nukkit.event.server.QueryRegenerateEvent;
 import cn.nukkit.inventory.*;
 import cn.nukkit.item.Item;
@@ -908,9 +909,10 @@ public class Server {
 
     private void checkTickUpdates(int currentTick, long tickTime) {
         for (Player p : new ArrayList<>(this.players.values())) {
-            if (!p.loggedIn && (tickTime - p.creationTime) >= 10000) {
-                p.close("", "Login timeout");
-            } else if (this.alwaysTickPlayers) {
+            if (!p.loggedIn && (tickTime - p.creationTime) >= 10000 && p.kick(PlayerKickEvent.Reason.LOGIN_TIMOUT)) {
+                continue;
+            }
+            if (this.alwaysTickPlayers) {
                 p.onUpdate(currentTick);
             }
         }

--- a/src/main/java/cn/nukkit/command/defaults/BanCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/BanCommand.java
@@ -3,9 +3,8 @@ package cn.nukkit.command.defaults;
 import cn.nukkit.Player;
 import cn.nukkit.command.Command;
 import cn.nukkit.command.CommandSender;
+import cn.nukkit.event.player.PlayerKickEvent;
 import cn.nukkit.lang.TranslationContainer;
-
-import java.util.Objects;
 
 /**
  * author: MagicDroidX
@@ -44,7 +43,7 @@ public class BanCommand extends VanillaCommand {
 
         Player player = sender.getServer().getPlayerExact(name);
         if (player != null) {
-            player.kick(!Objects.equals(reason, "") ? "Banned by admin. Reason: " + reason : "Banned by admin");
+            player.kick(PlayerKickEvent.Reason.NAME_BANNED, !reason.isEmpty() ? "Banned by admin. Reason: " + reason : "Banned by admin");
         }
 
         Command.broadcastCommandMessage(sender, new TranslationContainer("%commands.ban.success", player != null ? player.getName() : name));

--- a/src/main/java/cn/nukkit/command/defaults/BanIpCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/BanIpCommand.java
@@ -3,15 +3,14 @@ package cn.nukkit.command.defaults;
 import cn.nukkit.Player;
 import cn.nukkit.command.Command;
 import cn.nukkit.command.CommandSender;
+import cn.nukkit.event.player.PlayerKickEvent;
 import cn.nukkit.lang.TranslationContainer;
 import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -90,7 +89,7 @@ public class BanIpCommand extends VanillaCommand {
 
         for (Player player : new ArrayList<>(sender.getServer().getOnlinePlayers().values())) {
             if (player.getAddress().equals(ip)) {
-                player.kick(!Objects.equals(reason, "") ? reason : "IP banned.");
+                player.kick(PlayerKickEvent.Reason.IP_BANNED, !reason.isEmpty() ? reason : "IP banned");
             }
         }
 

--- a/src/main/java/cn/nukkit/command/defaults/KickCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/KickCommand.java
@@ -3,6 +3,7 @@ package cn.nukkit.command.defaults;
 import cn.nukkit.Player;
 import cn.nukkit.command.Command;
 import cn.nukkit.command.CommandSender;
+import cn.nukkit.event.player.PlayerKickEvent;
 import cn.nukkit.lang.TranslationContainer;
 import cn.nukkit.utils.TextFormat;
 
@@ -40,7 +41,7 @@ public class KickCommand extends VanillaCommand {
 
         Player player = sender.getServer().getPlayer(name);
         if (player != null) {
-            player.kick(reason);
+            player.kick(PlayerKickEvent.Reason.KICKED_BY_ADMIN);
             if (reason.length() >= 1) {
                 Command.broadcastCommandMessage(sender,
                         new TranslationContainer("commands.kick.success.reason", new String[]{player.getName(), reason})

--- a/src/main/java/cn/nukkit/event/player/PlayerKickEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerKickEvent.java
@@ -8,28 +8,64 @@ import cn.nukkit.lang.TextContainer;
 public class PlayerKickEvent extends PlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
+    public enum Reason {
+        NEW_CONNECTION,
+        KICKED_BY_ADMIN,
+        NOT_WHITELISTED,
+        IP_BANNED,
+        NAME_BANNED,
+        INVALID_PVE,
+        LOGIN_TIMOUT,
+        SERVER_FULL,
+        FLYING_DISABLED,
+        UNKNOWN;
+
+        @Override
+        public String toString() {
+            return this.name();
+        }
+    }
+
     public static HandlerList getHandlers() {
         return handlers;
     }
 
     protected TextContainer quitMessage;
 
-    protected final String reason;
+    protected final Reason reason;
+    protected final String reasonString;
 
+    @Deprecated
+    public PlayerKickEvent(Player player, String reason, String quitMessage) {
+        this(player, Reason.UNKNOWN, reason, new TextContainer(quitMessage));
+    }
+
+    @Deprecated
     public PlayerKickEvent(Player player, String reason, TextContainer quitMessage) {
+        this(player, Reason.UNKNOWN, reason, quitMessage);
+    }
+
+    public PlayerKickEvent(Player player, Reason reason, TextContainer quitMessage) {
+        this(player, reason, reason.toString(), quitMessage);
+    }
+
+    public PlayerKickEvent(Player player, Reason reason, String quitMessage) {
+        this(player, reason, new TextContainer(quitMessage));
+    }
+
+    public PlayerKickEvent(Player player, Reason reason, String reasonString, TextContainer quitMessage) {
         this.player = player;
         this.quitMessage = quitMessage;
         this.reason = reason;
-    }
-
-    public PlayerKickEvent(Player player, String reason, String quitMessage) {
-        this.player = player;
-        this.quitMessage = new TextContainer(quitMessage);
-        this.reason = reason;
+        this.reasonString = reason.name();
     }
 
     public String getReason() {
-        return reason;
+        return reason.toString();
+    }
+
+    public Reason getReasonEnum() {
+        return this.reason;
     }
 
     public TextContainer getQuitMessage() {

--- a/src/main/java/cn/nukkit/event/player/PlayerKickEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerKickEvent.java
@@ -61,7 +61,7 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
     }
 
     public String getReason() {
-        return reason.toString();
+        return reasonString;
     }
 
     public Reason getReasonEnum() {


### PR DESCRIPTION
Keeps old methods for compatiblity, but all existing code now uses the
PlayerKickEvent.Reason so it can be properly identified in an event.