### PR TITLE
Use fastmove instead of move, it is much faster and saves CPU.

### DIFF
--- a/src/main/java/cn/nukkit/entity/item/EntityItem.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityItem.java
@@ -143,7 +143,7 @@ public class EntityItem extends Entity {
                 hasUpdate = true;
             }
 
-            this.move(this.motionX, this.motionY, this.motionZ);
+            this.fastmove(this.motionX, this.motionY, this.motionZ);
 
             double friction = 1 - this.getDrag();
 


### PR DESCRIPTION
This will make items move faster (and help stop lag on Nukkit).