### PR TITLE
Fix block slab registration, and regsiter unknown on failure

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -342,7 +342,7 @@ public abstract class Block extends Position implements Metadatable, Cloneable {
             list[GOLD_BLOCK] = BlockGold.class;
             list[IRON_BLOCK] = BlockIron.class;
             list[DOUBLE_SLAB] = BlockDoubleSlabStone.class;
-            list[SLAB] = BlockSlab.class;
+            list[SLAB] = BlockSlabStone.class;
             list[BRICKS_BLOCK] = BlockBricks.class;
             list[TNT] = BlockTNT.class;
             list[BOOKSHELF] = BlockBookshelf.class;
@@ -519,6 +519,9 @@ public abstract class Block extends Position implements Metadatable, Cloneable {
                         }
                     } catch (Exception e) {
                         Server.getInstance().getLogger().error("Error while registering " + c.getName(), e);
+                        for (int data = 0; data < 16; ++data) {
+                            fullList[(id << 4) | data] = new BlockUnknown(id, data);
+                        }
                         return;
                     }
 
@@ -543,7 +546,7 @@ public abstract class Block extends Position implements Metadatable, Cloneable {
                 } else {
                     lightFilter[id] = 1;
                     for (int data = 0; data < 16; ++data) {
-                        fullList[(id) << 4 | data] = new BlockUnknown(id, data);
+                        fullList[(id << 4) | data] = new BlockUnknown(id, data);
                     }
                 }
             }


### PR DESCRIPTION
Previously the stone slab wouldn't register, leaving the block as null. When the level attempts to get that block (e.g. interacting with a stone slab) it would throw the error, and potentially crash the server.