### PR TITLE
Add y-coordinate check to Vector3 .equals

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockPumpkin.java
+++ b/src/main/java/cn/nukkit/block/BlockPumpkin.java
@@ -15,7 +15,7 @@ public class BlockPumpkin extends BlockSolid {
     }
 
     public BlockPumpkin(int meta) {
-        super(0);
+        super(meta);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/math/BlockVector3.java
+++ b/src/main/java/cn/nukkit/math/BlockVector3.java
@@ -1,7 +1,5 @@
 package cn.nukkit.math;
 
-import cn.nukkit.block.Block;
-
 public class BlockVector3 implements Cloneable {
     public static final int SIDE_DOWN = 0;
     public static final int SIDE_UP = 1;

--- a/src/main/java/cn/nukkit/math/BlockVector3.java
+++ b/src/main/java/cn/nukkit/math/BlockVector3.java
@@ -1,5 +1,7 @@
 package cn.nukkit.math;
 
+import cn.nukkit.block.Block;
+
 public class BlockVector3 implements Cloneable {
     public static final int SIDE_DOWN = 0;
     public static final int SIDE_UP = 1;
@@ -185,7 +187,10 @@ public class BlockVector3 implements Cloneable {
 
         if (!(ob instanceof BlockVector3)) return false;
 
-        return this.x == ((BlockVector3) ob).x && this.z == ((BlockVector3) ob).z;
+        return
+                this.x == ((BlockVector3) ob).x &&
+                this.y == ((BlockVector3) ob).y &&
+                this.z == ((BlockVector3) ob).z;
     }
 
     @Override


### PR DESCRIPTION
Asking for a block at y-coordinate 255 currently returns whatever is at y-coordinate 0 (usually Bedrock) rather than recognising that 255 is an invalid y-coordinate and returning 0 (Air)