### PR TITLE
Fix BlockStemMelon, BlockStemPumpkin

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockStemMelon.java
+++ b/src/main/java/cn/nukkit/block/BlockStemMelon.java
@@ -32,7 +32,7 @@ public class BlockStemMelon extends BlockCrops {
     @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_NORMAL) {
-            if (this.getSide(0).isTransparent()) {
+            if (this.getSide(0).getId() != FARMLAND) {
                 this.getLevel().useBreakOn(this);
                 return Level.BLOCK_UPDATE_NORMAL;
             }

--- a/src/main/java/cn/nukkit/block/BlockStemPumpkin.java
+++ b/src/main/java/cn/nukkit/block/BlockStemPumpkin.java
@@ -32,7 +32,7 @@ public class BlockStemPumpkin extends BlockCrops {
     @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_NORMAL) {
-            if (this.getSide(0).isTransparent()) {
+            if (this.getSide(0).getId() != FARMLAND) {
                 this.getLevel().useBreakOn(this);
                 return Level.BLOCK_UPDATE_NORMAL;
             }


### PR DESCRIPTION
if you are placing a melon seed or pumpkin seed, it just changed to item entity. because BlockFarmland is extends BlockTransparent, so "useBreakOn(this)" method is executed.

this pr is fix the problem.