### PR TITLE
Implement "notifyACK" method, change AvailableCommandsPacket to use "needsACK", fixes #1378

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -497,7 +497,23 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         if (count > 0) {
             //TODO: structure checking
             pk.commands = new Gson().toJson(data);
-            this.dataPacket(pk);
+            int identifier = this.dataPacket(pk, true); // We *need* ACK so we can be sure that the client received the packet or not
+            Thread t = new Thread() {
+                public void run() {
+                    while (true) {
+                        // We are going to wait 3 seconds, if after 3 seconds we didn't receive a reply from the client, resend the packet.
+                        try {
+                            Thread.sleep(3000);
+                            boolean status = needACK.get(identifier);
+                            if (!status && isOnline()) {
+                                sendCommandData();
+                                return;
+                            }
+                        } catch (InterruptedException e) {}
+                    }
+                }
+            };
+            t.start();
         }
     }
 
@@ -4467,5 +4483,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         }
         Player other = (Player) obj;
         return Objects.equals(this.getUniqueId(), other.getUniqueId()) && this.getId() == other.getId();
+    }
+    
+    /**
+     * Notifies an ACK response from the client
+     * 
+     * @param identification
+     */
+    public void notifyACK(int identification) {
+        needACK.put(identification, true);
     }
 }

--- a/src/main/java/cn/nukkit/network/RakNetInterface.java
+++ b/src/main/java/cn/nukkit/network/RakNetInterface.java
@@ -193,7 +193,10 @@ public class RakNetInterface implements ServerInstance, AdvancedSourceInterface 
 
     @Override
     public void notifyACK(String identifier, int identifierACK) {
-
+        // TODO: Better ACK notification implementation!
+        for (Player p : server.getOnlinePlayers().values()) {
+            p.notifyACK(identifierACK);
+        }
     }
 
     @Override


### PR DESCRIPTION
For some reason, while Nukkit processes the ACK notification, it doesn't do anything with it, so yes, any packet that were using "notifyACK" couldn't do anything with the notification, after all it wouldn't never receive it.

This commit changes that, it implements a very very very basic notifyACK method, changing the player's "needsACK" map (which wasn't used for NOTHING before this commit except adding packets that used the "needsACK" boolean (but it would just stay there with a "false" value so...)) to true if the server receives a notification from the client showing that yes, the client received the packet successfully.

Why that matters? This allows us to know IF the packet reached the client, allowing us to do a workaround for the #1378 issue.

So now we send a packet saying "hey client, when you receive the AvailableCommandsPacket packet, could you send a notification to the server showing that yes, you received it?", then, after sending, a thread is created (so we don't hang the main thread) and, after 3 seconds, if we DIDN'T receive the client's notification about receiving the AvailableCommandsPacket, we try sending again the packet until the player successfully receives it. (or if he logs out, whatever comes first)

Also a note: I couldn't test it on a very populated server, so... can someone test this commit on a public server before pushing to master? I tested on my local server and it worked, but I didn't have a chance to test on a public server.