### PR TITLE
Fix Item Frames

### DIFF
--- a/src/main/java/cn/nukkit/blockentity/BlockEntityItemFrame.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityItemFrame.java
@@ -1,5 +1,6 @@
 package cn.nukkit.blockentity;
 
+import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockAir;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
@@ -32,7 +33,7 @@ public class BlockEntityItemFrame extends BlockEntitySpawnable {
 
     @Override
     public boolean isBlockEntityValid() {
-        return this.getBlock().getId() == Item.ITEM_FRAME;
+        return this.getBlock().getId() == Block.ITEM_FRAME_BLOCK; // #BlamePub4Gamer this.getBlock().getId() == Item.ITEM_FRAME;
     }
 
     public int getItemRotation() {
@@ -89,8 +90,9 @@ public class BlockEntityItemFrame extends BlockEntitySpawnable {
                 .putInt("y", (int) this.y)
                 .putInt("z", (int) this.z)
                 .putCompound("Item", item ? NBTIO.putItemHelper(new ItemBlock(new BlockAir())) : NBTItem)
-                .putByte("ItemRotation", item ? 0 : this.getItemRotation())
-                .putFloat("ItemDropChance", this.getItemDropChance());
+                .putByte("ItemRotation", item ? 0 : this.getItemRotation());
+                // TODO: This crashes the client, why?
+                // .putFloat("ItemDropChance", this.getItemDropChance());
 
     }
 }


### PR DESCRIPTION
#BlamePub4Game

~~**TODO:** You still can't take out items from the Item Frame, however at least placing an Item Frame:~~
1. Doesn't crash the client
2. Isn't invisible

**UPDATE:** Pull this, then pull https://github.com/Nukkit/Nukkit/pull/1422 to fix the TODO issue.

![http://i.imgur.com/S9JOG1r.png](http://i.imgur.com/S9JOG1r.png)