### PR TITLE
Synchronize console commands, warn when a plugin tries to run a command in a async task, fixes #1248

### DIFF
--- a/src/main/java/cn/nukkit/command/CommandReader.java
+++ b/src/main/java/cn/nukkit/command/CommandReader.java
@@ -67,7 +67,11 @@ public class CommandReader extends Thread implements InterruptibleThread {
                     ServerCommandEvent event = new ServerCommandEvent(Server.getInstance().getConsoleSender(), line);
                     Server.getInstance().getPluginManager().callEvent(event);
                     if (!event.isCancelled()) {
-                        Server.getInstance().dispatchCommand(event.getSender(), event.getCommand());
+                        Server.getInstance().getScheduler().scheduleTask(new Runnable() {
+                            public void run() {
+                                Server.getInstance().dispatchCommand(event.getSender(), event.getCommand());
+                            }
+                        });
                     }
                     Timings.serverCommandTimer.stopTiming();
                 } catch (Exception e) {


### PR DESCRIPTION
Also adds the ```Server#isPrimaryThread()``` to check if the current thread is the primary thread or not.

If a plugin tries to run a command in a async task, it warns the that a plugin is running a command in a async task. (Which is not good, see #1248)
![http://i.imgur.com/2dj0BWu.png](http://i.imgur.com/2dj0BWu.png)