### PR TITLE
TODO: REVERT - Added a workaround for client text duplication

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1610,9 +1610,19 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
         this.checkTeleportPosition();
 
+        // TODO: remove this workaround (broken client MCPE 1.0.0)
+        if (!messageQueue.isEmpty()) {
+            TextPacket pk = new TextPacket();
+            pk.type = TextPacket.TYPE_RAW;
+            pk.message = String.join("\n", messageQueue);
+            this.dataPacket(pk);
+            messageQueue.clear();
+        }
         return true;
     }
 
+    private ArrayList<String> messageQueue = new ArrayList<String>();
+    
     public void checkNetwork() {
         if (!this.isOnline()) {
             return;
@@ -3586,14 +3596,18 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     @Override
     public void sendMessage(String message) {
         String[] mes = this.server.getLanguage().translateString(message).split("\\n");
+        // TODO: Remove this workaround (broken client MCPE 1.0.0)
         for (String m : mes) {
+            messageQueue.add(m);
+        }
+        /* for (String m : mes) {
             if (!"".equals(m)) {
                 TextPacket pk = new TextPacket();
                 pk.type = TextPacket.TYPE_RAW;
                 pk.message = m;
                 this.dataPacket(pk);
             }
-        }
+        } */
     }
 
     @Override

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3595,19 +3595,15 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
     @Override
     public void sendMessage(String message) {
-        String[] mes = this.server.getLanguage().translateString(message).split("\\n");
         // TODO: Remove this workaround (broken client MCPE 1.0.0)
-        for (String m : mes) {
-            messageQueue.add(m);
-        }
-        /* for (String m : mes) {
-            if (!"".equals(m)) {
-                TextPacket pk = new TextPacket();
-                pk.type = TextPacket.TYPE_RAW;
-                pk.message = m;
-                this.dataPacket(pk);
-            }
-        } */
+        messageQueue.add(this.server.getLanguage().translateString(message));
+
+        /*
+        TextPacket pk = new TextPacket();
+        pk.type = TextPacket.TYPE_RAW;
+        pk.message = this.server.getLanguage().translateString(message);
+        this.dataPacket(pk);
+        */
     }
 
     @Override


### PR DESCRIPTION
Doesn't fix 100% the dupe issue, but it's better than now.

Before:
![http://i.imgur.com/ZSn1dy6.png](http://i.imgur.com/ZSn1dy6.png)

After:
![http://i.imgur.com/FGzFGwh.png](http://i.imgur.com/FGzFGwh.png)
(The only issue is that only one message dupe... well, at least it's better than what it is now)

From PM-MP: https://github.com/pmmp/PocketMine-MP/commit/52748fcf64830453967fab4b43d6e823aeb37ecf