### PR TITLE
Fix EntityArmorChangeEvent check, fixes #1434

### DIFF
--- a/src/main/java/cn/nukkit/entity/EntityHumanType.java
+++ b/src/main/java/cn/nukkit/entity/EntityHumanType.java
@@ -175,7 +175,7 @@ public abstract class EntityHumanType extends EntityCreature implements Inventor
                 if (armor.getDamage() >= armor.getMaxDurability()) {
                     inventory.setArmorItem(slot, new ItemBlock(new BlockAir()));
                 } else {
-                    inventory.setArmorItem(slot, armor);
+                    inventory.setArmorItem(slot, armor, true);
                 }
             }
         }

--- a/src/main/java/cn/nukkit/inventory/PlayerInventory.java
+++ b/src/main/java/cn/nukkit/inventory/PlayerInventory.java
@@ -166,9 +166,13 @@ public class PlayerInventory extends BaseInventory {
     }
 
     public boolean setArmorItem(int index, Item item) {
-        return this.setItem(this.getSize() + index, item);
+        return this.setArmorItem(this.getSize() + index, item, false);
     }
 
+    public boolean setArmorItem(int index, Item item, boolean ignoreArmorEvents) {
+        return this.setItem(this.getSize() + index, item, ignoreArmorEvents);
+    }
+    
     public Item getHelmet() {
         return this.getItem(this.getSize());
     }
@@ -203,6 +207,10 @@ public class PlayerInventory extends BaseInventory {
 
     @Override
     public boolean setItem(int index, Item item) {
+        return setItem(index, item, false);
+    }
+
+    private boolean setItem(int index, Item item, boolean ignoreArmorEvents) {
         if (index < 0 || index >= this.size) {
             return false;
         } else if (item.getId() == 0 || item.getCount() <= 0) {
@@ -210,7 +218,7 @@ public class PlayerInventory extends BaseInventory {
         }
 
         //Armor change
-        if (index >= this.getSize()) {
+        if (!ignoreArmorEvents && index >= this.getSize()) {
             EntityArmorChangeEvent ev = new EntityArmorChangeEvent(this.getHolder(), this.getItem(index), item, index);
             Server.getInstance().getPluginManager().callEvent(ev);
             if (ev.isCancelled() && this.getHolder() != null) {
@@ -234,7 +242,7 @@ public class PlayerInventory extends BaseInventory {
 
         return true;
     }
-
+    
     @Override
     public boolean clear(int index) {
         if (this.slots.containsKey(index)) {


### PR DESCRIPTION
Before this commit, EntityArmorChangeEvent was triggered every time the player received any kind of damage, and this is not the expected behavior since it is "EntityArmorChangeEvent", not "EntityArmorDamagedEvent".

So, to fix this, a new setItem/setArmorItem method needed to be created, allowing to bypass the armor change event check, fixing the issue.

**Taking damage:** No event thrown (expected behavior)
**Changing armors:** Event thrown (expected behavior)

Fixes https://github.com/Nukkit/Nukkit/issues/1434