### PR TITLE
Fix typo on Enchantment#UD_WATER_WORKER, deprecate old value

### DIFF
--- a/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
+++ b/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
@@ -34,7 +34,12 @@ public abstract class Enchantment implements Cloneable {
     public static final int ID_PROTECTION_PROJECTILE = 4;
     public static final int ID_THORNS = 5;
     public static final int ID_WATER_BREATHING = 6;
+    /**
+     * @deprecated Use {@link #ID_WATER_WORKER}, this value is deprecated due to a typo on it's name;
+     */
+    @Deprecated
     public static final int UD_WATER_WORKER = 7;
+    public static final int ID_WATER_WORKER = 7;
     public static final int ID_WATER_WALKER = 8;
     public static final int ID_DAMAGE_ALL = 9;
     public static final int ID_DAMAGE_SMITE = 10;
@@ -63,7 +68,7 @@ public abstract class Enchantment implements Cloneable {
         enchantments[ID_PROTECTION_PROJECTILE] = new EnchantmentProtectionProjectile();
         enchantments[ID_THORNS] = new EnchantmentThorns();
         enchantments[ID_WATER_BREATHING] = new EnchantmentWaterBreath();
-        enchantments[UD_WATER_WORKER] = new EnchantmentWaterWorker();
+        enchantments[ID_WATER_WORKER] = new EnchantmentWaterWorker();
         enchantments[ID_WATER_WALKER] = new EnchantmentWaterWalker();
         enchantments[ID_DAMAGE_ALL] = new EnchantmentDamageAll();
         enchantments[ID_DAMAGE_SMITE] = new EnchantmentDamageSmite();

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentWaterWorker.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentWaterWorker.java
@@ -6,7 +6,7 @@ package cn.nukkit.item.enchantment;
  */
 public class EnchantmentWaterWorker extends Enchantment {
     protected EnchantmentWaterWorker() {
-        super(UD_WATER_WORKER, "waterWorker", 2, EnchantmentType.ARMOR_HEAD);
+        super(ID_WATER_WORKER, "waterWorker", 2, EnchantmentType.ARMOR_HEAD);
     }
 
     @Override


### PR DESCRIPTION
Yay for backwards compatibility.

**TODO:** Remove the old value (when the API is bumped to something else that isn't 1.0.0... come on, it's 2017, the API bump should happen one day)