### PR TITLE
Disable titleTick()

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -1079,8 +1079,10 @@ public class Server {
         return true;
     }
 
+    // TODO: Fix title
+    // It is now printing in the console the title instead of... well, not printing in the console
     public void titleTick() {
-        if (!Nukkit.ANSI) {
+        if (true || !Nukkit.ANSI) {
             return;
         }
 


### PR DESCRIPTION
I know that the fancy title is cool, but due to changes in https://github.com/Nukkit/Nukkit/commit/23b035e7f0659434b44286c0554947ef3f9f67f8 the title is changed BUT it is also printed in the console for some reason.