### PR TITLE
Disable titleTick()

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -1079,8 +1079,9 @@ public class Server {
         return true;
     }
 
+    // TODO: Fix title tick
     public void titleTick() {
-        if (!Nukkit.ANSI) {
+        if (true || !Nukkit.ANSI) {
             return;
         }
 


### PR DESCRIPTION
Okay, so now I could reproduce this issue again.
![http://i.imgur.com/Usyf5MW.png](http://i.imgur.com/Usyf5MW.png)
Disabling titleTick() fixes this, I will take a look on how to fix the titleTick() later, but for now, it is better disabling it. (if kept enabled, it will flood the console like in that screenshot)