### PR TITLE
BossBar API

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4362,7 +4362,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         attr.setValue(length); // Entity health
         pkAttributes.entries = new Attribute[] { attr };
         this.dataPacket(pkAttributes);
-        this.createBossBar("wow", 100);
         // And then the boss bar text
         SetEntityDataPacket pkMetadata = new SetEntityDataPacket();
         pkMetadata.eid = bossBarId;

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4347,6 +4347,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     }
     
     /**
+     * Updates a BossBar
      * 
      * @param text  The new BossBar message
      * @param length  The new BossBar length
@@ -4386,6 +4387,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     
     /**
      * Removes a BossBar
+     * 
      * @param bossBarId  The BossBar ID
      */
     public void removeBossBar(long bossBarId) {

--- a/src/main/java/cn/nukkit/network/protocol/BossEventPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/BossEventPacket.java
@@ -10,6 +10,10 @@ public class BossEventPacket extends DataPacket {
     public long eid;
     public int type;
 
+    public static final int ADD = 0;
+    public static final int UPDATE = 1;
+    public static final int REMOVE = 2;
+    
     @Override
     public byte pid() {
         return NETWORK_ID;


### PR DESCRIPTION
Adds a simple BossBar API.

You can create BossBar with ```Player#createBossBar("Hello World!", 100);```, this will return a bossBarId, store it for further use.

You can also update BossBar with ```Player#updateBossBar("New Text", 50, bossBarId);```, this will change the BossBar to show "New Text" and it will be half full.

And you can delete it with ```Player#deleteBossBar(bossBarId);```.

**TODO:** Nukkit is missing the Attributes value in AddEntityPacket, however sending the Attributes in the AddEntityPacket causes issues, client bug? (So, while this isn't fixed, the code uses UpdateAttributesPacket)