### PR TITLE
Pocket Protocol Update (101/MCPE 1.0.3.0) (#1454)

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
+++ b/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
@@ -9,9 +9,9 @@ public interface ProtocolInfo {
     /**
      * Actual Minecraft: PE protocol version
      */
-    byte CURRENT_PROTOCOL = 100;
-    String MINECRAFT_VERSION = "v1.0.0";
-    String MINECRAFT_VERSION_NETWORK = "1.0.0";
+    byte CURRENT_PROTOCOL = 101;
+    String MINECRAFT_VERSION = "v1.0.3.0";
+    String MINECRAFT_VERSION_NETWORK = "1.0.3.0";
 
     byte LOGIN_PACKET = 0x01;
     byte PLAY_STATUS_PACKET = 0x02;
@@ -93,4 +93,5 @@ public interface ProtocolInfo {
     byte RESOURCE_PACK_DATA_INFO_PACKET = 0x4f;
     byte RESOURCE_PACK_CHUNK_DATA_PACKET = 0x50;
     byte RESOURCE_PACK_CHUNK_REQUEST_PACKET = 0x51;
+    byte TRANSFER_PACKET = 0x52;
 }

--- a/src/main/java/cn/nukkit/network/protocol/TransferPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/TransferPacket.java
@@ -1,0 +1,27 @@
+package cn.nukkit.network.protocol;
+
+// A wild TransferPacket appeared!
+public class TransferPacket extends DataPacket {
+    public static final byte NETWORK_ID = ProtocolInfo.TRANSFER_PACKET;
+    
+    public String address; // Server address
+    public short port = 19132; // Server port
+    
+    @Override
+    public void decode() {
+        this.address = this.getString();
+        this.port = (short) this.getLShort();
+    }
+
+    @Override
+    public void encode() {
+        this.reset();
+        this.putString(address);
+        this.putLShort(port);
+    }
+
+    @Override
+    public byte pid() {
+        return ProtocolInfo.TRANSFER_PACKET;
+    }
+}


### PR DESCRIPTION
* Autogenerated data for 1.0.3.0

From PM-MP: https://github.com/pmmp/PocketMine-MP/commit/bf6e8db941d4efae9859b2f773f275c533e34cd1

* Add TransferPacket (Doesn't work yet)

From ClearSky https://github.com/ClearSkyTeam/PocketMine-MP/commit/b2f2cd31bc4df1ded9101b2fa5bb01073e9b35f6

Doesn't work yet, the client disconnects from the server, shows "Connecting..." and then shows "Can't reach server"

* Short -> Little endian short, fixes TransferPacket

Thanks @Kripth :wink:

* Added default port 19132

From PM-MP: https://github.com/pmmp/PocketMine-MP/commit/770155500595e7537d74abeac08ed9ced629296c

* Should be 19132, not 1932

Thanks @Guillaume351 :wink: