### PR TITLE
Add NukkitRunnable

### DIFF
--- a/src/main/java/cn/nukkit/scheduler/NukkitRunnable.java
+++ b/src/main/java/cn/nukkit/scheduler/NukkitRunnable.java
@@ -20,37 +20,37 @@ public abstract class NukkitRunnable implements Runnable {
 
     public synchronized Runnable runTask(Plugin plugin) throws IllegalArgumentException, IllegalStateException {
         checkState();
-        this.taskHandler = Server.getInstance().getScheduler().scheduleTask(this);
+        this.taskHandler = Server.getInstance().getScheduler().scheduleTask(plugin, this);
         return taskHandler.getTask();
     }
 
     public synchronized Runnable runTaskAsynchronously(Plugin plugin) throws IllegalArgumentException, IllegalStateException  {
         checkState();
-        this.taskHandler = Server.getInstance().getScheduler().scheduleTask(this, true);
+        this.taskHandler = Server.getInstance().getScheduler().scheduleTask(plugin, this, true);
         return taskHandler.getTask();
     }
 
     public synchronized Runnable runTaskLater(Plugin plugin, int delay) throws IllegalArgumentException, IllegalStateException  {
         checkState();
-        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedTask(this, delay);
+        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedTask(plugin, this, delay);
         return taskHandler.getTask();
     }
 
     public synchronized Runnable runTaskLaterAsynchronously(Plugin plugin, int delay) throws IllegalArgumentException, IllegalStateException  {
         checkState();
-        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedTask(this, delay, true);
+        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedTask(plugin, this, delay, true);
         return taskHandler.getTask();
     }
 
     public synchronized Runnable runTaskTimer(Plugin plugin, int delay, int period) throws IllegalArgumentException, IllegalStateException  {
         checkState();
-        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedRepeatingTask(this, delay, period);
+        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedRepeatingTask(plugin, this, delay, period);
         return taskHandler.getTask();
     }
 
     public synchronized Runnable runTaskTimerAsynchronously(Plugin plugin, int delay, int period) throws IllegalArgumentException, IllegalStateException  {
         checkState();
-        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedRepeatingTask(this, delay, period, true);
+        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedRepeatingTask(plugin, this, delay, period, true);
         return taskHandler.getTask();
     }
 

--- a/src/main/java/cn/nukkit/scheduler/NukkitRunnable.java
+++ b/src/main/java/cn/nukkit/scheduler/NukkitRunnable.java
@@ -1,0 +1,76 @@
+package cn.nukkit.scheduler;
+
+import cn.nukkit.Server;
+import cn.nukkit.plugin.Plugin;
+
+/**
+ * This class is provided as an easy way to handle scheduling tasks.
+ */
+public abstract class NukkitRunnable implements Runnable {
+    private TaskHandler taskHandler;
+
+    /**
+     * Attempts to cancel this task.
+     *
+     * @throws IllegalStateException if task was not scheduled yet
+     */
+    public synchronized void cancel() throws IllegalStateException {
+        taskHandler.cancel();
+    }
+
+    public synchronized Runnable runTask(Plugin plugin) throws IllegalArgumentException, IllegalStateException {
+        checkState();
+        this.taskHandler = Server.getInstance().getScheduler().scheduleTask(this);
+        return taskHandler.getTask();
+    }
+
+    public synchronized Runnable runTaskAsynchronously(Plugin plugin) throws IllegalArgumentException, IllegalStateException  {
+        checkState();
+        this.taskHandler = Server.getInstance().getScheduler().scheduleTask(this, true);
+        return taskHandler.getTask();
+    }
+
+    public synchronized Runnable runTaskLater(Plugin plugin, int delay) throws IllegalArgumentException, IllegalStateException  {
+        checkState();
+        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedTask(this, delay);
+        return taskHandler.getTask();
+    }
+
+    public synchronized Runnable runTaskLaterAsynchronously(Plugin plugin, int delay) throws IllegalArgumentException, IllegalStateException  {
+        checkState();
+        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedTask(this, delay, true);
+        return taskHandler.getTask();
+    }
+
+    public synchronized Runnable runTaskTimer(Plugin plugin, int delay, int period) throws IllegalArgumentException, IllegalStateException  {
+        checkState();
+        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedRepeatingTask(this, delay, period);
+        return taskHandler.getTask();
+    }
+
+    public synchronized Runnable runTaskTimerAsynchronously(Plugin plugin, int delay, int period) throws IllegalArgumentException, IllegalStateException  {
+        checkState();
+        this.taskHandler = Server.getInstance().getScheduler().scheduleDelayedRepeatingTask(this, delay, period, true);
+        return taskHandler.getTask();
+    }
+
+    /**
+     * Gets the task id for this runnable.
+     *
+     * @return the task id that this runnable was scheduled as
+     * @throws IllegalStateException if task was not scheduled yet
+     */
+    public synchronized int getTaskId() throws IllegalStateException {
+        if (taskHandler == null) {
+            throw new IllegalStateException("Not scheduled yet");
+        }
+        final int id = taskHandler.getTaskId();
+        return id;
+    }
+
+    private void checkState() {
+        if (taskHandler != null) {
+            throw new IllegalStateException("Already scheduled as " + taskHandler.getTaskId());
+        }
+    }
+}


### PR DESCRIPTION
Using Nukkit Scheduler is a mess, so I created NukkitRunnable.

It works just like BukkitRunnable... except it is for Nukkit 😉 

Example:
```
        new NukkitRunnable() {
            public void run() {
                for (Player p : Server.getInstance().getOnlinePlayers().values()) {
                    if (bossBars.containsKey(p)) {
                        long bossBar = bossBars.get(p);
                        p.updateBossBar("Hello World! §a§l" + TasselUtils.getRandom().nextInt(0, 800), 100, bossBar);
                    } else {
                        long bossBar = p.createBossBar("Temporary", 100);
                        bossBars.put(p, bossBar);
                    }
                }
            }
        }.runTaskTimer(this, 20, 20);
```

**Why I done this instead of using Nukkit Scheduler?**
Nukkit Scheduler doesn't let you cancel the task inside of the task, making you need to create a lot of unnecessary variables, bloating a lot your code.

Also, it's nice, and it works without any issues.