### PR TITLE
Tasks should be cancelled on reload, deprecate old methods

### DIFF
--- a/src/main/java/cn/nukkit/scheduler/ServerScheduler.java
+++ b/src/main/java/cn/nukkit/scheduler/ServerScheduler.java
@@ -45,18 +45,42 @@ public class ServerScheduler {
         return addTask(task, 0, 0, false);
     }
 
+    /**
+     * @deprecated Use {@link #scheduleTask(Plugin, Runnable)
+     */
+    @Deprecated
     public TaskHandler scheduleTask(Runnable task) {
         return addTask(null, task, 0, 0, false);
     }
 
+    public TaskHandler scheduleTask(Plugin plugin, Runnable task) {
+        return addTask(plugin, task, 0, 0, false);
+    }
+    
+    /**
+     * @deprecated Use {@link #scheduleTask(Plugin, Runnable, boolean)
+     */
+    @Deprecated
     public TaskHandler scheduleTask(Runnable task, boolean asynchronous) {
         return addTask(null, task, 0, 0, asynchronous);
     }
 
+    public TaskHandler scheduleTask(Plugin plugin, Runnable task, boolean asynchronous) {
+        return addTask(plugin, task, 0, 0, asynchronous);
+    }
+    
+    /**
+     * @deprecated Use {@link #scheduleAsyncTask(Plugin, AsyncTask)
+     */
+    @Deprecated
     public TaskHandler scheduleAsyncTask(AsyncTask task) {
         return addTask(null, task, 0, 0, true);
     }
 
+    public TaskHandler scheduleAsyncTask(Plugin plugin, AsyncTask task) {
+        return addTask(plugin, task, 0, 0, true);
+    }
+    
     @Deprecated
     public void scheduleAsyncTaskToWorker(AsyncTask task, int worker) {
         scheduleAsyncTask(task);
@@ -78,22 +102,54 @@ public class ServerScheduler {
         return this.addTask(task, delay, 0, asynchronous);
     }
 
+    /**
+     * @deprecated Use {@link #scheduleDelayedTask(Plugin, Runnable, int)
+     */
+    @Deprecated
     public TaskHandler scheduleDelayedTask(Runnable task, int delay) {
         return addTask(null, task, delay, 0, false);
     }
 
+    public TaskHandler scheduleDelayedTask(Plugin plugin, Runnable task, int delay) {
+        return addTask(plugin, task, delay, 0, false);
+    }
+    
+    /**
+     * @deprecated Use {@link #scheduleDelayedTask(Plugin, Runnable, int, boolean)
+     */
+    @Deprecated
     public TaskHandler scheduleDelayedTask(Runnable task, int delay, boolean asynchronous) {
         return addTask(null, task, delay, 0, asynchronous);
     }
 
+    public TaskHandler scheduleDelayedTask(Plugin plugin, Runnable task, int delay, boolean asynchronous) {
+        return addTask(plugin, task, delay, 0, asynchronous);
+    }
+    
+    /**
+     * @deprecated Use {@link #scheduleRepeatingTask(Plugin, Runnable, int)
+     */
+    @Deprecated
     public TaskHandler scheduleRepeatingTask(Runnable task, int period) {
         return addTask(null, task, 0, period, false);
     }
+    
+    public TaskHandler scheduleRepeatingTask(Plugin plugin, Runnable task, int period) {
+        return addTask(plugin, task, 0, period, false);
+    }
 
+    /**
+     * @deprecated Use {@link #scheduleRepeatingTask(Plugin, Runnable, int, boolean)
+     */
+    @Deprecated
     public TaskHandler scheduleRepeatingTask(Runnable task, int period, boolean asynchronous) {
         return addTask(null, task, 0, period, asynchronous);
     }
 
+    public TaskHandler scheduleRepeatingTask(Plugin plugin, Runnable task, int period, boolean asynchronous) {
+        return addTask(plugin, task, 0, period, asynchronous);
+    }
+    
     public TaskHandler scheduleRepeatingTask(Task task, int period) {
         return addTask(task, 0, period, false);
     }
@@ -110,12 +166,28 @@ public class ServerScheduler {
         return addTask(task, delay, period, asynchronous);
     }
 
+    /**
+     * @deprecated Use {@link #scheduleDelayedRepeatingTask(Plugin, Runnable, int, int)
+     */
+    @Deprecated
     public TaskHandler scheduleDelayedRepeatingTask(Runnable task, int delay, int period) {
         return addTask(null, task, delay, period, false);
     }
+    
+    public TaskHandler scheduleDelayedRepeatingTask(Plugin plugin, Runnable task, int delay, int period) {
+        return addTask(plugin, task, delay, period, false);
+    }
 
+    /**
+     * @deprecated Use {@link #scheduleDelayedRepeatingTask(Plugin, Runnable, int, int, boolean)
+     */
+    @Deprecated
     public TaskHandler scheduleDelayedRepeatingTask(Runnable task, int delay, int period, boolean asynchronous) {
         return addTask(null, task, delay, period, asynchronous);
+    }
+    
+    public TaskHandler scheduleDelayedRepeatingTask(Plugin plugin, Runnable task, int delay, int period, boolean asynchronous) {
+        return addTask(plugin, task, delay, period, asynchronous);
     }
 
     public void cancelTask(int taskId) {
@@ -134,7 +206,9 @@ public class ServerScheduler {
         }
         for (Map.Entry<Integer, TaskHandler> entry : taskMap.entrySet()) {
             TaskHandler taskHandler = entry.getValue();
-            if (plugin.equals(taskHandler.getPlugin())) {
+            // TODO: Remove the "taskHandler.getPlugin() == null" check
+            // It is only there for backwards compatibility!
+            if (taskHandler.getPlugin() == null || plugin.equals(taskHandler.getPlugin())) {
                 try {
                     taskHandler.cancel(); /* It will remove from task map automatic in next main heartbeat. */
                 } catch (RuntimeException ex) {


### PR DESCRIPTION
Fixes #1458 

The tasks were never cancelled on reload because the plugin instance was always "null", so the code to cancel on reload were never executed.

Also fixes Tasks "onCancel" methods.

This pull request is required for https://github.com/Nukkit/Nukkit/pull/1457