### PR TITLE
Only allow sugarcane to replace a block of air

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockSugarcane.java
+++ b/src/main/java/cn/nukkit/block/BlockSugarcane.java
@@ -96,6 +96,9 @@ public class BlockSugarcane extends BlockFlowable {
 
     @Override
     public boolean place(Item item, Block block, Block target, int face, double fx, double fy, double fz, Player player) {
+        if (block.getId() != AIR) {
+            return false;
+        }
         Block down = this.getSide(0);
         if (down.getId() == SUGARCANE_BLOCK) {
             this.getLevel().setBlock(block, new BlockSugarcane(), true);


### PR DESCRIPTION
Currently sugar cane blocks can be placed on water blocks, either at the surface or deep down.  This fix ensures only air blocks are replaced.