### PR TITLE
Fixing water holes

### DIFF
--- a/src/main/java/cn/nukkit/item/ItemBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemBucket.java
@@ -4,6 +4,7 @@ import cn.nukkit.Player;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockAir;
 import cn.nukkit.block.BlockLiquid;
+import cn.nukkit.block.BlockWater;
 import cn.nukkit.event.player.PlayerBucketEmptyEvent;
 import cn.nukkit.event.player.PlayerBucketFillEvent;
 import cn.nukkit.level.Level;
@@ -73,6 +74,27 @@ public class ItemBucket extends Item {
                 player.getServer().getPluginManager().callEvent(ev = new PlayerBucketFillEvent(player, block, face, this, result));
                 if (!ev.isCancelled()) {
                     player.getLevel().setBlock(target, new BlockAir(), true, true);
+
+                    // When water is removed ensure any adjacent still water is
+                    // replaced with water that can flow.
+                    Block north = target.getSide(target.SIDE_NORTH);
+                    Block south = target.getSide(target.SIDE_SOUTH);
+                    Block east = target.getSide(target.SIDE_EAST);
+                    Block west = target.getSide(target.SIDE_WEST);
+
+                    if (north.getId() == STILL_WATER) {
+                        level.setBlock(north, new BlockWater());
+                    }
+                    if (south.getId() == STILL_WATER) {
+                        level.setBlock(south, new BlockWater());
+                    }
+                    if (east.getId() == STILL_WATER) {
+                        level.setBlock(east, new BlockWater());
+                    }
+                    if (west.getId() == STILL_WATER) {
+                        level.setBlock(west, new BlockWater());
+                    }
+
                     if (player.isSurvival()) {
                         Item clone = this.clone();
                         clone.setCount(this.getCount() - 1);

--- a/src/main/java/cn/nukkit/item/ItemBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemBucket.java
@@ -15,6 +15,8 @@ import cn.nukkit.level.Level;
  */
 public class ItemBucket extends Item {
 
+    private static final int[] SIDES_NSEW = new int[]{ Block.SIDE_NORTH, Block.SIDE_SOUTH, Block.SIDE_EAST, Block.SIDE_WEST };
+
     public ItemBucket() {
         this(0, 1);
     }
@@ -77,22 +79,11 @@ public class ItemBucket extends Item {
 
                     // When water is removed ensure any adjacent still water is
                     // replaced with water that can flow.
-                    Block north = target.getSide(target.SIDE_NORTH);
-                    Block south = target.getSide(target.SIDE_SOUTH);
-                    Block east = target.getSide(target.SIDE_EAST);
-                    Block west = target.getSide(target.SIDE_WEST);
-
-                    if (north.getId() == STILL_WATER) {
-                        level.setBlock(north, new BlockWater());
-                    }
-                    if (south.getId() == STILL_WATER) {
-                        level.setBlock(south, new BlockWater());
-                    }
-                    if (east.getId() == STILL_WATER) {
-                        level.setBlock(east, new BlockWater());
-                    }
-                    if (west.getId() == STILL_WATER) {
-                        level.setBlock(west, new BlockWater());
+                    for (int side : this.SIDES_NSEW) {
+                        Block b = target.getSide(side);
+                        if (b.getId() == STILL_WATER) {
+                            level.setBlock(b, new BlockWater());
+                        }
                     }
 
                     if (player.isSurvival()) {


### PR DESCRIPTION
When STILL_WATER is removed using a bucket we now look for adjacent STILL_WATER and change it to WATER.  This WATER is now able to flow into the space where the STILL_WATER was removed.

The change avoids problems like this:
![screenshot_20170208-231519](https://cloud.githubusercontent.com/assets/7370644/22762521/a70ca5d2-ee57-11e6-9247-d3cd074df037.png)

It looks like the same fix is required for lava, but I haven't checked.  I'll take a look another time.