### PR TITLE
Pocket Protocol Update (101/MCPE 1.0.3.0) (#1454)

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -66,11 +66,11 @@ import cn.nukkit.utils.TextFormat;
 import cn.nukkit.utils.Zlib;
 import co.aikar.timings.Timing;
 import co.aikar.timings.Timings;
-
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.ByteOrder;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -198,6 +198,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     private BlockEnderChest viewingEnderChest = null;
     
     protected int lastEnderPearl = -1;
+
+    private String deviceModel;
 
     public BlockEnderChest getViewingEnderChest() {
         return viewingEnderChest;
@@ -1977,6 +1979,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     } else {
                         this.setSkin(loginPacket.getSkin());
                     }
+
+                    this.deviceModel = loginPacket.deviceModel;
 
                     PlayerPreLoginEvent playerPreLoginEvent;
                     this.server.getPluginManager().callEvent(playerPreLoginEvent = new PlayerPreLoginEvent(this, "Plugin reason"));
@@ -4460,6 +4464,21 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             this.movementSpeed += sprintSpeedChange;
         }
         this.setMovementSpeed(this.movementSpeed);
+    }
+
+    public void transfer(InetSocketAddress address) {
+        String hostName = address.getHostName();
+        int port = address.getPort();
+        TransferPacket pk = new TransferPacket();
+        pk.address = hostName;
+        pk.port = port;
+        this.dataPacket(pk);
+        String message = "tranferred to " + address + ":" + port;
+        this.close(message, message, false);
+    }
+
+    public String getDeviceModel() {
+        return deviceModel;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/network/protocol/LoginPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/LoginPacket.java
@@ -27,6 +27,7 @@ public class LoginPacket extends DataPacket {
     public long clientId;
     public String identityPublicKey;
     public String serverAddress;
+    public String deviceModel;
 
     public Skin skin;
 
@@ -85,6 +86,7 @@ public class LoginPacket extends DataPacket {
         if (skinToken.has("ServerAddress")) this.serverAddress = skinToken.get("ServerAddress").getAsString();
         if (skinToken.has("SkinId")) skinId = skinToken.get("SkinId").getAsString();
         if (skinToken.has("SkinData")) this.skin = new Skin(skinToken.get("SkinData").getAsString(), skinId);
+        if (skinToken.has("DeviceModel")) this.deviceModel = skinToken.get("DeviceModel").getAsString();
     }
 
     private JsonObject decodeToken(String token) {

--- a/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
+++ b/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
@@ -10,8 +10,8 @@ public interface ProtocolInfo {
      * Actual Minecraft: PE protocol version
      */
     byte CURRENT_PROTOCOL = 101;
-    String MINECRAFT_VERSION = "v1.0.3.0";
-    String MINECRAFT_VERSION_NETWORK = "1.0.3.0";
+    String MINECRAFT_VERSION = "v1.0.3";
+    String MINECRAFT_VERSION_NETWORK = "1.0.3";
 
     byte LOGIN_PACKET = 0x01;
     byte PLAY_STATUS_PACKET = 0x02;

--- a/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
+++ b/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
@@ -9,9 +9,9 @@ public interface ProtocolInfo {
     /**
      * Actual Minecraft: PE protocol version
      */
-    byte CURRENT_PROTOCOL = 100;
-    String MINECRAFT_VERSION = "v1.0.0";
-    String MINECRAFT_VERSION_NETWORK = "1.0.0";
+    byte CURRENT_PROTOCOL = 101;
+    String MINECRAFT_VERSION = "v1.0.3.0";
+    String MINECRAFT_VERSION_NETWORK = "1.0.3.0";
 
     byte LOGIN_PACKET = 0x01;
     byte PLAY_STATUS_PACKET = 0x02;
@@ -93,4 +93,5 @@ public interface ProtocolInfo {
     byte RESOURCE_PACK_DATA_INFO_PACKET = 0x4f;
     byte RESOURCE_PACK_CHUNK_DATA_PACKET = 0x50;
     byte RESOURCE_PACK_CHUNK_REQUEST_PACKET = 0x51;
+    byte TRANSFER_PACKET = 0x52;
 }

--- a/src/main/java/cn/nukkit/network/protocol/TransferPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/TransferPacket.java
@@ -1,0 +1,27 @@
+package cn.nukkit.network.protocol;
+
+// A wild TransferPacket appeared!
+public class TransferPacket extends DataPacket {
+    public static final byte NETWORK_ID = ProtocolInfo.TRANSFER_PACKET;
+    
+    public String address; // Server address
+    public short port = 19132; // Server port
+    
+    @Override
+    public void decode() {
+        this.address = this.getString();
+        this.port = (short) this.getLShort();
+    }
+
+    @Override
+    public void encode() {
+        this.reset();
+        this.putString(address);
+        this.putLShort(port);
+    }
+
+    @Override
+    public byte pid() {
+        return ProtocolInfo.TRANSFER_PACKET;
+    }
+}

--- a/src/main/java/cn/nukkit/network/protocol/TransferPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/TransferPacket.java
@@ -5,7 +5,7 @@ public class TransferPacket extends DataPacket {
     public static final byte NETWORK_ID = ProtocolInfo.TRANSFER_PACKET;
     
     public String address; // Server address
-    public short port = 19132; // Server port
+    public int port = 19132; // Server port
     
     @Override
     public void decode() {


### PR DESCRIPTION
# 1.0.3.0 is already released to the public, so I think we can already merge this to master

* Autogenerated data for 1.0.3.0

From PM-MP: https://github.com/pmmp/PocketMine-MP/commit/bf6e8db941d4efae9859b2f773f275c533e34cd1

* Add TransferPacket (Doesn't work yet)

From ClearSky https://github.com/ClearSkyTeam/PocketMine-MP/commit/b2f2cd31bc4df1ded9101b2fa5bb01073e9b35f6

Doesn't work yet, the client disconnects from the server, shows "Connecting..." and then shows "Can't reach server"

* Short -> Little endian short, fixes TransferPacket

Thanks @Kripth :wink:

* Added default port 19132

From PM-MP: https://github.com/pmmp/PocketMine-MP/commit/770155500595e7537d74abeac08ed9ced629296c

* Should be 19132, not 1932

Thanks @Guillaume351 :wink: