### PR TITLE
' ' Fix error in many plugins

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1983,7 +1983,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         if ((c >= 'a' && c <= 'z') ||
                                 (c >= 'A' && c <= 'Z') ||
                                 (c >= '0' && c <= '9') ||
-                                c == '_' || c == ' '
+                                c == '_'
                                 ) {
                             continue;
                         }


### PR DESCRIPTION
As of 1.0.4, ' ' char now isn't blocked in MC: PE. However, when used with Config or in some plugins, it causes many errors