### PR TITLE
Give purpose to Stringenum

### DIFF
--- a/src/main/java/cn/nukkit/command/data/CommandParameterEnum
+++ b/src/main/java/cn/nukkit/command/data/CommandParameterEnum
@@ -1,0 +1,23 @@
+//Created by kvetinac97
+
+package cn.nukkit.command.data;
+
+public class CommandParameterEnum extends CommandParameter {
+
+    public String[] enum_values = new String[0];
+
+    public CommandParameterEnum(String name, boolean optional, String[] enumValues) {
+        super(name, "stringenum", optional);
+
+        this.enum_values = enumValues;
+    }
+
+    public CommandParameterEnum(String name, boolean optional) {
+        this(name, optional, new String[0]);
+    }
+
+    public CommandParameterEnum(String name) {
+        this(name, false);
+    }
+    
+}


### PR DESCRIPTION
Now, the stringenum option HAS sense.
![purpose](https://cloud.githubusercontent.com/assets/10753543/23993701/e1c25dba-0a41-11e7-94eb-ea1bc09cbf48.png)
