### PR TITLE
Make using commands easier for players

### DIFF
--- a/src/main/java/cn/nukkit/command/data/CommandParameter.java
+++ b/src/main/java/cn/nukkit/command/data/CommandParameter.java
@@ -12,9 +12,20 @@ public class CommandParameter {
     public final static String ARG_TYPE_RAW_TEXT = "rawtext";
     public final static String ARG_TYPE_INT = "int";
 
+    public static final String ENUM_TYPE_ITEM_LIST = "itemType";
+    public static final String ENUM_TYPE_BLOCK_LIST = "blockType";
+    public static final String ENUM_TYPE_COMMAND_LIST = "commandName";
+    public static final String ENUM_TYPE_ENCHANTMENT_LIST = "enchantmentType";
+    public static final String ENUM_TYPE_ENTITY_LIST = "entityType";
+    public static final String ENUM_TYPE_EFFECT_LIST = "effectType";
+    public static final String ENUM_TYPE_PARTICLE_LIST = "particleType";
+
     public String name;
     public String type;
     public boolean optional;
+
+    public String enum_type;
+    public String[] enum_values;
 
     public CommandParameter(String name, String type, boolean optional) {
         this.name = name;
@@ -28,6 +39,28 @@ public class CommandParameter {
 
     public CommandParameter(String name) {
         this(name, false);
+    }
+
+    public CommandParameter(String name, boolean optional, String enumType){
+        this.name = name;
+        this.type = ARG_TYPE_STRING_ENUM;
+        this.optional = optional;
+        this.enum_type = enumType;
+    }
+
+    public CommandParameter(String name, boolean optional, String[] enumValues){
+        this.name = name;
+        this.type = ARG_TYPE_STRING_ENUM;
+        this.optional = optional;
+        this.enum_values = enumValues;
+    }
+
+    public CommandParameter(String name, String enumType){
+        this(name, false, enumType);
+    }
+
+    public CommandParameter(String name, String[] enumValues){
+        this(name, false, enumValues);
     }
 
 }

--- a/src/main/java/cn/nukkit/command/defaults/DefaultGamemodeCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/DefaultGamemodeCommand.java
@@ -18,6 +18,10 @@ public class DefaultGamemodeCommand extends VanillaCommand {
         this.commandParameters.put("default", new CommandParameter[]{
                 new CommandParameter("mode", CommandParameter.ARG_TYPE_INT, false)
         });
+        this.commandParameters.put("byString", new CommandParameter[]{
+                new CommandParameter("mode", new String[]{"survival", "creative", "s", "c",
+                        "adventure", "a", "spectator", "view", "v"})
+        });
     }
 
     @Override

--- a/src/main/java/cn/nukkit/command/defaults/DifficultyCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/DifficultyCommand.java
@@ -22,6 +22,10 @@ public class DifficultyCommand extends VanillaCommand {
         this.commandParameters.put("default", new CommandParameter[]{
                 new CommandParameter("difficulty", CommandParameter.ARG_TYPE_INT, false)
         });
+        this.commandParameters.put("byString", new CommandParameter[]{
+                new CommandParameter("difficulty", new String[]{"peaceful", "p", "easy", "e",
+                    "normal", "n", "hard", "h"})
+        });
     }
 
     @Override

--- a/src/main/java/cn/nukkit/command/defaults/EffectCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/EffectCommand.java
@@ -21,10 +21,14 @@ public class EffectCommand extends Command {
         this.commandParameters.clear();
         this.commandParameters.put("default", new CommandParameter[]{
                 new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, false),
-                new CommandParameter("effect"),
+                new CommandParameter("effect", false, CommandParameter.ENUM_TYPE_EFFECT_LIST),
                 new CommandParameter("seconds", CommandParameter.ARG_TYPE_INT, true),
                 new CommandParameter("amplifier", true),
                 new CommandParameter("hideParticle", CommandParameter.ARG_TYPE_BOOL, true)
+        });
+        this.commandParameters.put("clear", new CommandParameter[]{
+                new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, false),
+                new CommandParameter("clear", new String[]{"clear"})
         });
     }
 

--- a/src/main/java/cn/nukkit/command/defaults/EffectCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/EffectCommand.java
@@ -21,7 +21,7 @@ public class EffectCommand extends Command {
         this.commandParameters.clear();
         this.commandParameters.put("default", new CommandParameter[]{
                 new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, false),
-                new CommandParameter("effect", false, CommandParameter.ENUM_TYPE_EFFECT_LIST),
+                new CommandParameter("effect", CommandParameter.ARG_TYPE_STRING, false), //Do not use Enum here because of buggy behavior
                 new CommandParameter("seconds", CommandParameter.ARG_TYPE_INT, true),
                 new CommandParameter("amplifier", true),
                 new CommandParameter("hideParticle", CommandParameter.ARG_TYPE_BOOL, true)

--- a/src/main/java/cn/nukkit/command/defaults/EnchantCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/EnchantCommand.java
@@ -21,7 +21,12 @@ public class EnchantCommand extends VanillaCommand {
         this.commandParameters.put("default", new CommandParameter[]{
                 new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, false),
                 new CommandParameter("enchantment ID", CommandParameter.ARG_TYPE_INT, false),
-                new CommandParameter("level", CommandParameter.ARG_TYPE_INT, true),
+                new CommandParameter("level", CommandParameter.ARG_TYPE_INT, true)
+        });
+        this.commandParameters.put("byName", new CommandParameter[]{
+                new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, false),
+                new CommandParameter("id", false, CommandParameter.ENUM_TYPE_ENCHANTMENT_LIST),
+                new CommandParameter("level", CommandParameter.ARG_TYPE_INT, true)
         });
     }
 
@@ -42,7 +47,7 @@ public class EnchantCommand extends VanillaCommand {
         int enchantId;
         int enchantLevel;
         try {
-            enchantId = Integer.parseInt(args[1]);
+            enchantId = getIdByName(args[1]);
             enchantLevel = args.length == 3 ? Integer.parseInt(args[2]) : 1;
         } catch (NumberFormatException e) {
             sender.sendMessage(new TranslationContainer("commands.generic.usage", this.usageMessage));
@@ -63,5 +68,62 @@ public class EnchantCommand extends VanillaCommand {
         player.getInventory().setItemInHand(item);
         Command.broadcastCommandMessage(sender, new TranslationContainer("%commands.enchant.success"));
         return true;
+    }
+
+    public int getIdByName(String value) throws NumberFormatException {
+        switch (value){
+            case "protection":
+                return 0;
+            case "fire_protection":
+                return 1;
+            case "feather_falling":
+                return 2;
+            case "blast_protection":
+                return 3;
+            case "projectile_projection":
+                return 4;
+            case "thorns":
+                return 5;
+            case "respiration":
+                return 6;
+            case "aqua_affinity":
+                return 7;
+            case "depth_strider":
+                return 8;
+            case "sharpness":
+                return 9;
+            case "smite":
+                return 10;
+            case "bane_of_arthropods":
+                return 11;
+            case "knockback":
+                return 12;
+            case "fire_aspect":
+                return 13;
+            case "looting":
+                return 14;
+            case "efficiency":
+                return 15;
+            case "silk_touch":
+                return 16;
+            case "durability":
+                return 17;
+            case "fortune":
+                return 18;
+            case "power":
+                return 19;
+            case "punch":
+                return 20;
+            case "flame":
+                return 21;
+            case "infinity":
+                return 22;
+            case "luck_of_the_sea":
+                return 23;
+            case "lure":
+                return 24;
+            default:
+                return Integer.parseInt(value);
+        }
     }
 }

--- a/src/main/java/cn/nukkit/command/defaults/GamemodeCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/GamemodeCommand.java
@@ -22,6 +22,11 @@ public class GamemodeCommand extends VanillaCommand {
                 new CommandParameter("mode", CommandParameter.ARG_TYPE_INT, false),
                 new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, true)
         });
+        this.commandParameters.put("byString", new CommandParameter[]{
+                new CommandParameter("mode", new String[]{"survival", "creative", "s", "c",
+                        "adventure", "a", "spectator", "view", "v"}),
+                new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, true)
+        });
     }
 
     @Override

--- a/src/main/java/cn/nukkit/command/defaults/GiveCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/GiveCommand.java
@@ -24,6 +24,18 @@ public class GiveCommand extends VanillaCommand {
                 new CommandParameter("meta", CommandParameter.ARG_TYPE_INT, true),
                 new CommandParameter("tags...", CommandParameter.ARG_TYPE_RAW_TEXT, true)
         });
+        this.commandParameters.put("toPlayerById", new CommandParameter[]{
+                new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, false),
+                new CommandParameter("item ID", CommandParameter.ARG_TYPE_INT, false),
+                new CommandParameter("amount", CommandParameter.ARG_TYPE_INT, true),
+                new CommandParameter("tags...", CommandParameter.ARG_TYPE_RAW_TEXT, true)
+        });
+        this.commandParameters.put("toPlayerByIdMeta", new CommandParameter[]{
+                new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, false),
+                new CommandParameter("item ID:meta", CommandParameter.ARG_TYPE_RAW_TEXT, false),
+                new CommandParameter("amount", CommandParameter.ARG_TYPE_INT, true),
+                new CommandParameter("tags...", CommandParameter.ARG_TYPE_RAW_TEXT, true)
+        });
     }
 
     @Override

--- a/src/main/java/cn/nukkit/command/defaults/GiveCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/GiveCommand.java
@@ -17,22 +17,11 @@ public class GiveCommand extends VanillaCommand {
         super(name, "%nukkit.command.give.description", "%nukkit.command.give.usage");
         this.setPermission("nukkit.command.give");
         this.commandParameters.clear();
-        this.commandParameters.put("toPlayerById", new CommandParameter[]{
+        this.commandParameters.put("default", new CommandParameter[]{
                 new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, false),
-                new CommandParameter("item ID", CommandParameter.ARG_TYPE_INT, false),
+                new CommandParameter("item", false, CommandParameter.ENUM_TYPE_ITEM_LIST),
                 new CommandParameter("amount", CommandParameter.ARG_TYPE_INT, true),
-                new CommandParameter("tags...", CommandParameter.ARG_TYPE_RAW_TEXT, true)
-        });
-        this.commandParameters.put("toPlayerByIdMeta", new CommandParameter[]{
-                new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, false),
-                new CommandParameter("item ID:meta", CommandParameter.ARG_TYPE_RAW_TEXT, false),
-                new CommandParameter("amount", CommandParameter.ARG_TYPE_INT, true),
-                new CommandParameter("tags...", CommandParameter.ARG_TYPE_RAW_TEXT, true)
-        });
-        this.commandParameters.put("toPlayerByName", new CommandParameter[]{
-                new CommandParameter("player", CommandParameter.ARG_TYPE_TARGET, false),
-                new CommandParameter("item name", CommandParameter.ARG_TYPE_STRING, false),
-                new CommandParameter("amount", CommandParameter.ARG_TYPE_INT, true),
+                new CommandParameter("meta", CommandParameter.ARG_TYPE_INT, true),
                 new CommandParameter("tags...", CommandParameter.ARG_TYPE_RAW_TEXT, true)
         });
     }


### PR DESCRIPTION
This commit introduces two new fields to ArgType called stringenum : enum_values (you can predefine which strings can be used by player) and enum_type (blockList, itemList... so MCPE will automatically display list of all supported blocks, items)

Screenshots:
![purpose2](https://cloud.githubusercontent.com/assets/10753543/24050034/fedc1322-0b2d-11e7-9d54-cb30826419f6.png)
![purpose4](https://cloud.githubusercontent.com/assets/10753543/24050038/fee80740-0b2d-11e7-92fa-9297791c5b3e.png)
![purpose5](https://cloud.githubusercontent.com/assets/10753543/24050037/fee76402-0b2d-11e7-9e8c-486a76b0a939.png)
![purpose6](https://cloud.githubusercontent.com/assets/10753543/24050039/feeecfd0-0b2d-11e7-83b2-b2075c5109f5.png)

Example of usage in plugin:


![purpose](https://cloud.githubusercontent.com/assets/10753543/24050036/fedf74ae-0b2d-11e7-89eb-f4ceb63be1af.png)
![purpose3](https://cloud.githubusercontent.com/assets/10753543/24050035/fedc137c-0b2d-11e7-8a55-ecf7acd6f21c.png)


