### PR TITLE
Fixes Enchanted Item NullPointerException Error

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1646,8 +1646,10 @@ public class Item implements Cloneable {
         for (CompoundTag entry : this.getNamedTag().getList("ench", CompoundTag.class).getAll()) {
             if (entry.getShort("id") == id) {
                 Enchantment e = Enchantment.getEnchantment(entry.getShort("id"));
-                e.setLevel(entry.getShort("lvl"));
-                return e;
+                if (e != null){
+                    e.setLevel(entry.getShort("lvl"));
+                    return e;
+                }
             }
         }
 
@@ -1706,8 +1708,10 @@ public class Item implements Cloneable {
         ListTag<CompoundTag> ench = this.getNamedTag().getList("ench", CompoundTag.class);
         for (CompoundTag entry : ench.getAll()) {
             Enchantment e = Enchantment.getEnchantment(entry.getShort("id"));
-            e.setLevel(entry.getShort("lvl"));
-            enchantments.add(e);
+            if (e != null){
+                e.setLevel(entry.getShort("lvl"));
+                enchantments.add(e);
+            } 
         }
 
         return enchantments.stream().toArray(Enchantment[]::new);

--- a/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
+++ b/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
@@ -93,7 +93,7 @@ public abstract class Enchantment implements Cloneable {
     }
 
     public static Enchantment getEnchantment(int id) {
-        return get(id).clone();
+        return get(id) == null ? null : get(id).clone();
     }
 
     public static Enchantment[] getEnchantments() {


### PR DESCRIPTION
Fixes the following error which stops a item with a incorrect enchantment from working.

`[ALERT] java.lang.NullPointerException at cn.nukkit.item.enchantment.Enchantment.getEnchantment(Enchantment.java:96) at cn.nukkit.item.Item.getEnchantments(Item.java:1710) at cn.nukkit.Player.handleDataPacket(Player.java:2752) at cn.nukkit.network.Network.processPackets(Network.java:185) at cn.nukkit.network.Network.processBatch(Network.java:156) at cn.nukkit.Player.handleDataPacket(Player.java:1895) at cn.nukkit.network.RakNetInterface.handleEncapsulated(RakNetInterface.java:155) at cn.nukkit.raknet.server.ServerHandler.handlePacket(ServerHandler.java:123) at cn.nukkit.network.RakNetInterface.process(RakNetInterface.java:66) at cn.nukkit.network.Network.processInterfaces(Network.java:76) at cn.nukkit.Server.tick(Server.java:1010) at cn.nukkit.Server.tickProcessor(Server.java:808) at cn.nukkit.Server.start(Server.java:787) at cn.nukkit.Server.<init>(Server.java:472) at cn.nukkit.Nukkit.main(Nukkit.java:68)`