### PR TITLE
Fixed arg type of TimeCommand

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,6 @@
             <artifactId>netty-all</artifactId>
             <version>4.1.6.Final</version>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-parent</artifactId>
-            <version>4.1.9.Final</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>netty-all</artifactId>
             <version>4.1.6.Final</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-parent</artifactId>
+            <version>4.1.9.Final</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
@@ -28,6 +28,10 @@ public class TimeCommand extends VanillaCommand {
                 new CommandParameter("add|set", CommandParameter.ARG_TYPE_STRING, false),
                 new CommandParameter("value", CommandParameter.ARG_TYPE_INT, false)
         });
+        this.commandParameters.put("2args_", new CommandParameter[]{
+                new CommandParameter("add|set", CommandParameter.ARG_TYPE_STRING, false),
+                new CommandParameter("value", CommandParameter.ARG_TYPE_STRING, false)
+        });
     }
 
     @Override

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -729,6 +729,7 @@ public class Level implements ChunkManager, Metadatable {
 
                         EntityLightning bolt = new EntityLightning(chunk, nbt);
                         LightningStrikeEvent ev = new LightningStrikeEvent(this, bolt);
+                        getServer().getPluginManager().callEvent(ev);
                         if (!ev.isCancelled()) {
                             bolt.spawnToAll();
                         } else {


### PR DESCRIPTION
####Fixed arg type of TimeCommand

**Here are time transformation codes:**  
  
  
int value;  
if ("day".equals(args[1])) {  
    &nbsp;&nbsp;&nbsp;&nbsp;value = Level.TIME_DAY;  
} else if ("night".equals(args[1])) {  
    &nbsp;&nbsp;&nbsp;&nbsp;value = Level.TIME_NIGHT;  
}  
  
  
**But the command parameters set that:**  
  
  
this.commandParameters.put("2args", new CommandParameter[]{  
    &nbsp;&nbsp;&nbsp;&nbsp;new CommandParameter("add|set", CommandParameter.ARG_TYPE_STRING, false),  
    &nbsp;&nbsp;&nbsp;&nbsp;new CommandParameter("value", CommandParameter.ARG_TYPE_INT, false)  
});  
  
**Arg 2 is int. So transformation does not work.  
And I just added String arg type:**  
  
  
this.commandParameters.put("2args_", new CommandParameter[]{  
    &nbsp;&nbsp;&nbsp;&nbsp;new CommandParameter("add|set", CommandParameter.ARG_TYPE_STRING, false),  
    &nbsp;&nbsp;&nbsp;&nbsp;new CommandParameter("value", CommandParameter.ARG_TYPE_STRING, false)  
});  


<HR style="border:1 dashed black" width="80%" color=black SIZE=1></HR>

####Fixed LightningStrike event will not be called

**The LightningStrikeEvent will not be called.**  

LightningStrikeEvent ev = new LightningStrikeEvent(this, bolt);
if (!ev.isCancelled()) {
    bolt.spawnToAll();
}

**Added PluginManager#callEvent(Event)**

LightningStrikeEvent ev = new LightningStrikeEvent(this, bolt);
getServer().getPluginManager().callEvent(ev);
if (!ev.isCancelled()) {
    bolt.spawnToAll();
}
