### PR TITLE
Fixed Farmland and BlockWaterStill

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockFarmland.java
+++ b/src/main/java/cn/nukkit/block/BlockFarmland.java
@@ -67,19 +67,27 @@ public class BlockFarmland extends BlockTransparent {
                 return 0;
             }
 
+            if (this.level.getBlock(v.setComponents(x, this.y + 1, z)).isSolid()) {
+                this.level.setBlock(this, new BlockDirt(), true, true);
+
+                return Level.BLOCK_UPDATE_RANDOM;
+            }
+
             boolean found = false;
 
-            for (int x = (int) this.x - 1; x <= this.x + 1; x++) {
-                for (int z = (int) this.z - 1; z <= this.z + 1; z++) {
-                    if (z == this.z && x == this.x) {
-                        continue;
-                    }
+            for (int x = (int) this.x - 4; x <= this.x + 4; x++) {
+                for (int z = (int) this.z - 4; z <= this.z + 4; z++) {
+                    for (int y = (int) this.y; y <= this.y + 1; y++) {
+                        if (z == this.z && x == this.x && y == this.y) {
+                            continue;
+                        }
 
-                    Block block = this.level.getBlock(v.setComponents(x, this.y, z));
+                        Block block = this.level.getBlock(v.setComponents(x, y, z));
 
-                    if (block instanceof BlockWater) {
-                        found = true;
-                        break;
+                        if (block instanceof BlockWater) {
+                            found = true;
+                            break;
+                        }
                     }
                 }
             }

--- a/src/main/java/cn/nukkit/block/BlockWaterStill.java
+++ b/src/main/java/cn/nukkit/block/BlockWaterStill.java
@@ -31,11 +31,4 @@ public class BlockWaterStill extends BlockWater {
         return new BlockWaterStill(meta);
     }
 
-    @Override
-    public int onUpdate(int type) {
-        if (type != Level.BLOCK_UPDATE_SCHEDULED) {
-            return super.onUpdate(type);
-        }
-        return 0;
-    }
 }


### PR DESCRIPTION
Farmland is hydrated how it is described in Minecraft Wiki (http://minecraft.gamepedia.com/Farmland):

"A farmland block will be created dry. It will become hydrated if the following conditions are met:
1) Water up to four blocks away horizontally, including diagonals.
2) The water must be on the same level or 1 block above farmland block level."


Allow scheduled update for BlockWaterStill. 
This is made because water should be flowed into the BlockAir or any other BlockFlowable. For example, when sheduled update for BlockWaterStill is not allowed, if you set a Dirt block instead of BlockWaterStill (underwater) and then break this block, the water will not flow into the empty space. Also, a torch setted on BlockWaterStill's place will not be washed out without sheduled update.