### PR TITLE
Compass position is updating now

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1010,6 +1010,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         }
         this.spawnPosition = new Position(pos.x, pos.y, pos.z, level);
         SetSpawnPositionPacket pk = new SetSpawnPositionPacket();
+        pk.spawnType = SetSpawnPositionPacket.TYPE_PLAYER_SPAWN;
         pk.x = (int) this.spawnPosition.x;
         pk.y = (int) this.spawnPosition.y;
         pk.z = (int) this.spawnPosition.z;
@@ -4368,6 +4369,15 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             this.server.getPluginManager().callEvent(event);
             if (event.isCancelled()) return false;
             to = event.getTo();
+            if (from.getLevel().getId() != to.getLevel().getId()){ //Different level, update compass position
+                SetSpawnPositionPacket pk = new SetSpawnPositionPacket();
+                pk.spawnType = SetSpawnPositionPacket.TYPE_WORLD_SPAWN;
+                Position spawn = to.getLevel().getSpawnLocation();
+                pk.x = spawn.getFloorX();
+                pk.y = spawn.getFloorY();
+                pk.z = spawn.getFloorZ();
+                dataPacket(pk);
+            }
         }
 
         Position oldPos = this.getPosition();
@@ -4405,6 +4415,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     }
 
     public void teleportImmediate(Location location, TeleportCause cause) {
+        Location from = this.getLocation();
         if (super.teleport(location, cause)) {
 
             for (Inventory window : new ArrayList<>(this.windowIndex.values())) {
@@ -4412,6 +4423,16 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     continue;
                 }
                 this.removeWindow(window);
+            }
+
+            if (from.getLevel().getId() != location.getLevel().getId()){ //Different level, update compass position
+                SetSpawnPositionPacket pk = new SetSpawnPositionPacket();
+                pk.spawnType = SetSpawnPositionPacket.TYPE_WORLD_SPAWN;
+                Position spawn = location.getLevel().getSpawnLocation();
+                pk.x = spawn.getFloorX();
+                pk.y = spawn.getFloorY();
+                pk.z = spawn.getFloorZ();
+                dataPacket(pk);
             }
 
             this.forceMovement = new Vector3(this.x, this.y, this.z);

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2418,7 +2418,7 @@ public class Level implements ChunkManager, Metadatable {
     public void setSpawnLocation(Vector3 pos) {
         Position previousSpawn = this.getSpawnLocation();
         this.provider.setSpawn(pos);
-        this.server.getPluginManager().callEvent(new SpawnChangeEvent(this, previousSpawn););
+        this.server.getPluginManager().callEvent(new SpawnChangeEvent(this, previousSpawn));
         SetSpawnPositionPacket pk = new SetSpawnPositionPacket();
         pk.spawnType = SetSpawnPositionPacket.TYPE_WORLD_SPAWN;
         pk.x = pos.getFloorX();

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2418,16 +2418,13 @@ public class Level implements ChunkManager, Metadatable {
     public void setSpawnLocation(Vector3 pos) {
         Position previousSpawn = this.getSpawnLocation();
         this.provider.setSpawn(pos);
-        SpawnChangeEvent e = new SpawnChangeEvent(this, previousSpawn);
-        this.server.getPluginManager().callEvent(e);
-        if (!e.isCancelled()){
-            SetSpawnPositionPacket pk = new SetSpawnPositionPacket();
-            pk.spawnType = SetSpawnPositionPacket.TYPE_WORLD_SPAWN;
-            pk.x = pos.getFloorX();
-            pk.y = pos.getFloorY();
-            pk.z = pos.getFloorZ();
-            for (Player p : getPlayers().values()) p.dataPacket(pk);
-        }
+        this.server.getPluginManager().callEvent(new SpawnChangeEvent(this, previousSpawn););
+        SetSpawnPositionPacket pk = new SetSpawnPositionPacket();
+        pk.spawnType = SetSpawnPositionPacket.TYPE_WORLD_SPAWN;
+        pk.x = pos.getFloorX();
+        pk.y = pos.getFloorY();
+        pk.z = pos.getFloorZ();
+        for (Player p : getPlayers().values()) p.dataPacket(pk);
     }
 
     public void requestChunk(int x, int z, Player player) {

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2418,7 +2418,16 @@ public class Level implements ChunkManager, Metadatable {
     public void setSpawnLocation(Vector3 pos) {
         Position previousSpawn = this.getSpawnLocation();
         this.provider.setSpawn(pos);
-        this.server.getPluginManager().callEvent(new SpawnChangeEvent(this, previousSpawn));
+        SpawnChangeEvent e = new SpawnChangeEvent(this, previousSpawn);
+        this.server.getPluginManager().callEvent(e);
+        if (!e.isCancelled()){
+            SetSpawnPositionPacket pk = new SetSpawnPositionPacket();
+            pk.spawnType = SetSpawnPositionPacket.TYPE_WORLD_SPAWN;
+            pk.x = pos.getFloorX();
+            pk.y = pos.getFloorY();
+            pk.z = pos.getFloorZ();
+            for (Player p : getPlayers().values()) p.dataPacket(pk);
+        }
     }
 
     public void requestChunk(int x, int z, Player player) {

--- a/src/main/java/cn/nukkit/network/protocol/SetSpawnPositionPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/SetSpawnPositionPacket.java
@@ -7,11 +7,14 @@ public class SetSpawnPositionPacket extends DataPacket {
 
     public static final byte NETWORK_ID = ProtocolInfo.SET_SPAWN_POSITION_PACKET;
 
-    public int unknown;
+    public static final int TYPE_PLAYER_SPAWN = 0;
+    public static final int TYPE_WORLD_SPAWN = 1;
+
+    public int spawnType;
     public int y;
     public int z;
     public int x;
-    public boolean unknownBool;
+    public boolean spawnForced;
 
     @Override
     public void decode() {
@@ -21,9 +24,9 @@ public class SetSpawnPositionPacket extends DataPacket {
     @Override
     public void encode() {
         this.reset();
-        this.putUnsignedVarInt(this.unknown);
+        this.putVarInt(this.spawnType);
         this.putBlockCoords(this.x, this.y, this.z);
-        this.putBoolean(this.unknownBool);
+        this.putBoolean(this.spawnForced);
     }
 
     @Override


### PR DESCRIPTION
There were 2 uknown fields in SetSpawnPositionPacket. One of them, the VarInt (not UnsignedVarInt) one meant spawn type (player or world).
Now, when player switches world, or /setworldspawn command gets called, position compass is pointing to gets updated also (so the compass serves purpose now).