### PR TITLE
Unit testing & Enhanced VarInt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <junit.jupiter.version>5.0.0-M4</junit.jupiter.version>
+        <junit.platform.version>1.0.0-M4</junit.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -39,13 +41,13 @@
             <artifactId>jline</artifactId>
             <version>2.14.2</version>
         </dependency>
-		<dependency>
-			<!-- This dependency doesn't seem to be available in public maven repos.
-			     The jar file is included with the project under the lib dir.
-			     You need to manually install it in your local maven repo.  
-			     The command below should work if mvn is on your path and you are in the lib dir:
-			     mvn install:install-file -Dfile=leveldb.jar -DgroupId=com.tinfoiled.mcpe.leveldb -DartifactId=leveldb -Dversion=0.8 -Dpackaging=jar 
-			 -->
+        <dependency>
+            <!-- This dependency doesn't seem to be available in public maven repos.
+                 The jar file is included with the project under the lib dir.
+                 You need to manually install it in your local maven repo.
+                 The command below should work if mvn is on your path and you are in the lib dir:
+                 mvn install:install-file -Dfile=leveldb.jar -DgroupId=com.tinfoiled.mcpe.leveldb -DartifactId=leveldb -Dversion=0.8 -Dpackaging=jar
+             -->
             <groupId>com.tinfoiled.mcpe.leveldb</groupId>
             <artifactId>leveldb</artifactId>
             <version>0.8</version>
@@ -71,11 +73,42 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-		    <plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>${junit.platform.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
                 <version>2.5.2</version>

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1858,6 +1858,46 @@ public class Item implements Cloneable {
         return this;
     }
 
+    public String[] getLore() {
+        Tag tag = this.getNamedTagEntry("display");
+        ArrayList<String> lines = new ArrayList<>();
+
+        if (tag instanceof CompoundTag) {
+            CompoundTag nbt = (CompoundTag) tag;
+            ListTag<StringTag> lore = nbt.getList("Lore", StringTag.class);
+
+            if (lore.size() > 0) {
+                for (StringTag stringTag : lore.getAll()) {
+                    lines.add(stringTag.data);
+                }
+            }
+        }
+
+        return lines.toArray(new String[0]);
+    }
+
+    public void setLore(String... lines) {
+        CompoundTag tag;
+        if (!this.hasCompoundTag()) {
+            tag = new CompoundTag();
+        } else {
+            tag = this.getNamedTag();
+        }
+        ListTag<StringTag> lore = new ListTag<>("Lore");
+
+        for (String line : lines) {
+            lore.add(new StringTag("", line));
+        }
+
+        if (!tag.contains("display")) {
+            tag.putCompound("display", new CompoundTag("display").putList(lore));
+        } else {
+            tag.getCompound("display").putList(lore);
+        }
+
+        this.setNamedTag(tag);
+    }
+
     public Tag getNamedTagEntry(String name) {
         CompoundTag tag = this.getNamedTag();
         if (tag != null) {

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1835,47 +1835,6 @@ public class Item implements Cloneable {
         return lines.toArray(new String[0]);
     }
 
-    public Item setLore(String... lines) {
-        CompoundTag tag;
-        if (!this.hasCompoundTag()) {
-            tag = new CompoundTag();
-        } else {
-            tag = this.getNamedTag();
-        }
-        ListTag<StringTag> lore = new ListTag<>("Lore");
-
-        for (String line : lines) {
-            lore.add(new StringTag("", line));
-        }
-
-        if (!tag.contains("display")) {
-            tag.putCompound("display", new CompoundTag("display").putList(lore));
-        } else {
-            tag.getCompound("display").putList(lore);
-        }
-
-        this.setNamedTag(tag);
-        return this;
-    }
-
-    public String[] getLore() {
-        Tag tag = this.getNamedTagEntry("display");
-        ArrayList<String> lines = new ArrayList<>();
-
-        if (tag instanceof CompoundTag) {
-            CompoundTag nbt = (CompoundTag) tag;
-            ListTag<StringTag> lore = nbt.getList("Lore", StringTag.class);
-
-            if (lore.size() > 0) {
-                for (StringTag stringTag : lore.getAll()) {
-                    lines.add(stringTag.data);
-                }
-            }
-        }
-
-        return lines.toArray(new String[0]);
-    }
-
     public void setLore(String... lines) {
         CompoundTag tag;
         if (!this.hasCompoundTag()) {

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -363,6 +363,14 @@ public class BinaryStream {
         VarInt.writeVarLong(this, v);
     }
 
+    public long getUnsignedVarLong() {
+        return VarInt.readUnsignedVarLong(this);
+    }
+
+    public void putUnsignedVarLong(long v) {
+        VarInt.writeUnsignedVarLong(this, v);
+    }
+
     public BlockVector3 getBlockCoords() {
         return new BlockVector3(this.getVarInt(), (int) this.getUnsignedVarInt(), this.getVarInt());
     }

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -363,18 +363,6 @@ public class BinaryStream {
         VarInt.writeVarLong(this, v);
     }
 
-    public BigInteger getUnsignedVarLong() {
-        return VarInt.readUnsignedVarLong(this);
-    }
-
-    public void putUnsignedVarLong(long v) {
-        VarInt.writeUnsignedVarLong(this, BigInteger.valueOf(v));
-    }
-
-    public void putUnsignedVarLong(BigInteger v) {
-        VarInt.writeUnsignedVarLong(this, v);
-    }
-
     public BlockVector3 getBlockCoords() {
         return new BlockVector3(this.getVarInt(), (int) this.getUnsignedVarInt(), this.getVarInt());
     }

--- a/src/main/java/cn/nukkit/utils/VarInt.java
+++ b/src/main/java/cn/nukkit/utils/VarInt.java
@@ -1,10 +1,28 @@
 package cn.nukkit.utils;
 
+import cn.nukkit.api.API;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-public class VarInt {
+import static cn.nukkit.api.API.Definition.UNIVERSAL;
+import static cn.nukkit.api.API.Usage.EXPERIMENTAL;
+
+/**
+ * Tool class for VarInt or VarLong operations.
+ * <p>
+ * Some code from http://wiki.vg/Protocol.
+ *
+ * @author MagicDroidX
+ * @author lmlstarqaq
+ */
+@API(usage = EXPERIMENTAL, definition = UNIVERSAL)
+public final class VarInt {
+
+	private VarInt() {
+		//no instance
+	}
 
     /**
      * @param v Signed int

--- a/src/test/java/cn/nukkit/test/AngleTest.java
+++ b/src/test/java/cn/nukkit/test/AngleTest.java
@@ -1,56 +1,69 @@
 package cn.nukkit.test;
 
 import cn.nukkit.math.Angle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static cn.nukkit.math.Angle.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Copyright 2017 lmlstarqaq
  * All rights reserved.
  */
-public class AngleTest {
-  public static void main(String[] args) {
-    Angle rd1 = fromRadian(1.0);
-    Angle rf1 = fromRadian(1.0f);
-    Angle dd1 = fromDegree(180.0);
-    Angle df1 = fromDegree(180.0f);
 
-    System.out.println(rd1.asFloatDegree() + "\t" + rd1.asDoubleDegree() + "\t" + rd1.asFloatRadian() + "\t" + rd1.asDoubleRadian());
-    System.out.println(rf1.asFloatDegree() + "\t" + rf1.asDoubleDegree() + "\t" + rf1.asFloatRadian() + "\t" + rf1.asDoubleRadian());
-    System.out.println(dd1.asFloatDegree() + "\t" + dd1.asDoubleDegree() + "\t" + dd1.asFloatRadian() + "\t" + dd1.asDoubleRadian());
-    System.out.println(df1.asFloatDegree() + "\t" + df1.asDoubleDegree() + "\t" + df1.asFloatRadian() + "\t" + df1.asDoubleRadian());
-    System.out.println(rd1.toString());
-    System.out.println(rf1.toString());
-    System.out.println(dd1.toString());
-    System.out.println(df1.toString());
+@DisplayName("Angle")
+class AngleTest {
 
-    Angle rd2 = fromRadian(200.0);
-    Angle rf2 = fromRadian(200.0f);
-    Angle dd2 = fromDegree(23333.33);
-    Angle df2 = fromDegree(23333.33f);
+	@DisplayName("Angle operations")
+	@Test
+	void testAngle() {
+		Angle rd1 = fromRadian(1.0);
+		Angle rf1 = fromRadian(1.0f);
+		Angle dd1 = fromDegree(180.0);
+		Angle df1 = fromDegree(180.0f);
 
-    System.out.println(rd2.asFloatDegree() + "\t" + rd2.asDoubleDegree() + "\t" + rd2.asFloatRadian() + "\t" + rd2.asDoubleRadian());
-    System.out.println(rf2.asFloatDegree() + "\t" + rf2.asDoubleDegree() + "\t" + rf2.asFloatRadian() + "\t" + rf2.asDoubleRadian());
-    System.out.println(dd2.asFloatDegree() + "\t" + dd2.asDoubleDegree() + "\t" + dd2.asFloatRadian() + "\t" + dd2.asDoubleRadian());
-    System.out.println(df2.asFloatDegree() + "\t" + df2.asDoubleDegree() + "\t" + df2.asFloatRadian() + "\t" + df2.asDoubleRadian());
+		assertEquals("57.29578\t57.29577951308232\t1.0\t1.0", rd1.asFloatDegree() + "\t" + rd1.asDoubleDegree() + "\t" + rd1.asFloatRadian() + "\t" + rd1.asDoubleRadian());
+		assertEquals("57.295776\t57.29577951308232\t1.0\t1.0", rf1.asFloatDegree() + "\t" + rf1.asDoubleDegree() + "\t" + rf1.asFloatRadian() + "\t" + rf1.asDoubleRadian());
+		assertEquals("180.0\t180.0\t3.1415927\t3.141592653589793", dd1.asFloatDegree() + "\t" + dd1.asDoubleDegree() + "\t" + dd1.asFloatRadian() + "\t" + dd1.asDoubleRadian());
+		assertEquals("180.0\t180.0\t3.1415927\t3.141592653589793", df1.asFloatDegree() + "\t" + df1.asDoubleDegree() + "\t" + df1.asFloatRadian() + "\t" + df1.asDoubleRadian());
+		assertEquals("Angle[Double, 1.000000rad = 57.295780deg] [1072693248]", rd1.toString());
+		assertEquals("Angle[Float, 1.000000rad = 57.295776deg] [1065353216]", rf1.toString());
+		assertEquals("Angle[Double, 180.000000deg = 3.141593rad] [-341077452]", dd1.toString());
+		assertEquals("Angle[Float, 180.000000deg = 3.141593rad] [-386330060]", df1.toString());
 
-    System.out.println(rd1.sin() + "\t" + rd1.cos() + "\t" +rd1.tan());
-    System.out.println(dd1.sin() + "\t" + dd1.cos() + "\t" +dd1.tan());
+		Angle rd2 = fromRadian(200.0);
+		Angle rf2 = fromRadian(200.0f);
+		Angle dd2 = fromDegree(23333.33);
+		Angle df2 = fromDegree(23333.33f);
 
-    Angle asin1 = asin(1);
-    Angle asin2 = asin(1.0/2.0);
-    Angle acos1 = acos(1);
-    Angle acos2 = acos(1.0/2.0);
-    Angle atan1 = atan(1);
-    Angle atan2 = atan(1.0/2.0);
+		assertEquals("11459.156\t11459.155902616465\t200.0\t200.0", rd2.asFloatDegree() + "\t" + rd2.asDoubleDegree() + "\t" + rd2.asFloatRadian() + "\t" + rd2.asDoubleRadian());
+		assertEquals("11459.155\t11459.155902616465\t200.0\t200.0", rf2.asFloatDegree() + "\t" + rf2.asDoubleDegree() + "\t" + rf2.asFloatRadian() + "\t" + rf2.asDoubleRadian());
+		assertEquals("23333.33\t23333.33\t407.24344\t407.24343395436847", dd2.asFloatDegree() + "\t" + dd2.asDoubleDegree() + "\t" + dd2.asFloatRadian() + "\t" + dd2.asDoubleRadian());
+		assertEquals("23333.33\t23333.330078125\t407.24344\t407.243435317907", df2.asFloatDegree() + "\t" + df2.asDoubleDegree() + "\t" + df2.asFloatRadian() + "\t" + df2.asDoubleRadian());
 
-    System.out.println(asin1.toString() + "\t" + acos1.toString() + "\t" + atan1.toString());
-    System.out.println(asin2.toString() + "\t" + acos2.toString() + "\t" + atan2.toString());
+		assertEquals("0.8414709848078965\t0.5403023058681398\t1.5574077246549023", rd1.sin() + "\t" + rd1.cos() + "\t" +rd1.tan());
+		assertEquals("1.2246467991473532E-16\t-1.0\t-1.2246467991473532E-16", dd1.sin() + "\t" + dd1.cos() + "\t" +dd1.tan());
 
-    System.out.println(compare(asin(2.0/3.0), asin(1.0/2.0)));
+		Angle asin1 = asin(1);
+		Angle asin2 = asin(1.0/2.0);
+		Angle acos1 = acos(1);
+		Angle acos2 = acos(1.0/2.0);
+		Angle atan1 = atan(1);
+		Angle atan2 = atan(1.0/2.0);
 
-    System.out.println(fromRadian(22.0d).toString() + "\t" + fromRadian(22.0f).toString());
-    System.out.println(fromRadian(1.0d).toString() + "\t" + fromDegree(57.29577951308232d).toString());
-    System.out.println(fromRadian(1.0d).toString() + "\t" + fromDegree(1.0d).toString());
-  }
+		assertEquals("Angle[Double, 1.570796rad = 90.000000deg] [1807551715]\tAngle[Double, 0.000000rad = 0.000000deg] [0]\tAngle[Double, 0.785398rad = 45.000000deg] [1806503139]",
+				asin1.toString() + "\t" + acos1.toString() + "\t" + atan1.toString());
+		assertEquals("Angle[Double, 0.523599rad = 30.000000deg] [130921012]\tAngle[Double, 1.047198rad = 60.000000deg] [131969588]\tAngle[Double, 0.463648rad = 26.565051deg] [985405224]",
+				asin2.toString() + "\t" + acos2.toString() + "\t" + atan2.toString());
+
+		assertEquals(1, compare(asin(2.0/3.0), asin(1.0/2.0)));
+
+		assertEquals("Angle[Double, 22.000000rad = 1260.507149deg] [1077280768]\tAngle[Float, 22.000000rad = 1260.507080deg] [1102053376]",
+				fromRadian(22.0d).toString() + "\t" + fromRadian(22.0f).toString());
+		assertEquals("Angle[Double, 1.000000rad = 57.295780deg] [1072693248]\tAngle[Double, 57.295780deg = 1.000000rad] [-236816880]",
+						fromRadian(1.0d).toString() + "\t" + fromDegree(57.29577951308232d).toString());
+		assertEquals("Angle[Double, 1.000000rad = 57.295780deg] [1072693248]\tAngle[Double, 1.000000deg = 0.017453rad] [-1807936972]",
+				fromRadian(1.0d).toString() + "\t" + fromDegree(1.0d).toString());
+	}
 }

--- a/src/test/java/cn/nukkit/test/ClientChainDataTest.java
+++ b/src/test/java/cn/nukkit/test/ClientChainDataTest.java
@@ -1,10 +1,13 @@
 package cn.nukkit.test;
 
 import cn.nukkit.utils.ClientChainData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * An example to show how to use ClientChainData
@@ -13,49 +16,53 @@ import java.util.Objects;
  * By lmlstarqaq http://snake1999.com/
  * Creation time: 2017/6/7 15:07.
  */
-public class ClientChainDataTest {
-  public static void main(String[] args) throws Exception {
-    InputStream is = ClientChainDataTest.class.getResourceAsStream("chain.dat");
-    ClientChainData data = ClientChainData.of(readStream(is));
-    String got = String.format("userName=%s, clientUUID=%s, " +
-                    "identityPublicKey=%s, clientId=%d, " +
-                    "serverAddress=%s, deviceModel=%s, " +
-                    "deviceOS=%d, gameVersion=%s, " +
-                    "guiScale=%d, languageCode=%s, " +
-                    "xuid=%s, currentInputMode=%d, " +
-                    "defaultInputMode=%d, ADRole=%s," +
-                    "tenantId=%s, UIProfile=%d"
-            ,
-            data.getUsername(), data.getClientUUID(),
-            data.getIdentityPublicKey(), data.getClientId(),
-            data.getServerAddress(), data.getDeviceModel(),
-            data.getDeviceOS(), data.getGameVersion(),
-            data.getGuiScale(), data.getLanguageCode(),
-            data.getXUID(), data.getCurrentInputMode(),
-            data.getDefaultInputMode(), data.getADRole(),
-            data.getTenantId(), data.getUIProfile()
-    );
-    String expecting = "userName=lmlstarqaq, clientUUID=8323afe1-641e-3b61-9a92-d5d20b279065, " +
-            "identityPublicKey=MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4lyvA1iVhV2u3pLQqJAjJnJZSlSjib8mM1uB5h5yqOBSvCHW+nZxDmkOAW6MS1GA7yGHitGmfS4jW/yUISUdWvLzEWJYOzphb3GNh5J1oLJRwESc5278i4MEDk1y21/q, " +
-            "clientId=-6315607246631494544, " +
-            "serverAddress=192.168.1.108:19132, deviceModel=iPhone6,2, " +
-            "deviceOS=2, gameVersion=1.1.0, " +
-            "guiScale=0, languageCode=zh_CN, " +
-            "xuid=2535465134455915, currentInputMode=2, " +
-            "defaultInputMode=2, ADRole=2,tenantId=, " +
-            "UIProfile=1";
-    assert Objects.equals(got, expecting);
-  }
+@DisplayName("ClientChainData")
+class ClientChainDataTest {
 
-  private static byte[] readStream(InputStream inStream) throws Exception {
-    ByteArrayOutputStream outSteam = new ByteArrayOutputStream();
-    byte[] buffer = new byte[65536];
-    int len;
-    while ((len = inStream.read(buffer)) != -1) {
-      outSteam.write(buffer, 0, len);
-    }
-    outSteam.close();
-    inStream.close();
-    return outSteam.toByteArray();
-  }
+	@DisplayName("Getters")
+	@Test
+	void testGetter() throws Exception {
+		InputStream is = ClientChainDataTest.class.getResourceAsStream("chain.dat");
+		ClientChainData data = ClientChainData.of(readStream(is));
+		String got = String.format("userName=%s, clientUUID=%s, " +
+						"identityPublicKey=%s, clientId=%d, " +
+						"serverAddress=%s, deviceModel=%s, " +
+						"deviceOS=%d, gameVersion=%s, " +
+						"guiScale=%d, languageCode=%s, " +
+						"xuid=%s, currentInputMode=%d, " +
+						"defaultInputMode=%d, ADRole=%s," +
+						"tenantId=%s, UIProfile=%d"
+				,
+				data.getUsername(), data.getClientUUID(),
+				data.getIdentityPublicKey(), data.getClientId(),
+				data.getServerAddress(), data.getDeviceModel(),
+				data.getDeviceOS(), data.getGameVersion(),
+				data.getGuiScale(), data.getLanguageCode(),
+				data.getXUID(), data.getCurrentInputMode(),
+				data.getDefaultInputMode(), data.getADRole(),
+				data.getTenantId(), data.getUIProfile()
+		);
+		String expecting = "userName=lmlstarqaq, clientUUID=8323afe1-641e-3b61-9a92-d5d20b279065, " +
+				"identityPublicKey=MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4lyvA1iVhV2u3pLQqJAjJnJZSlSjib8mM1uB5h5yqOBSvCHW+nZxDmkOAW6MS1GA7yGHitGmfS4jW/yUISUdWvLzEWJYOzphb3GNh5J1oLJRwESc5278i4MEDk1y21/q, " +
+				"clientId=-6315607246631494544, " +
+				"serverAddress=192.168.1.108:19132, deviceModel=iPhone6,2, " +
+				"deviceOS=2, gameVersion=1.1.0, " +
+				"guiScale=0, languageCode=zh_CN, " +
+				"xuid=2535465134455915, currentInputMode=2, " +
+				"defaultInputMode=2, ADRole=2,tenantId=, " +
+				"UIProfile=1";
+		assertEquals(got, expecting);
+	}
+
+	private static byte[] readStream(InputStream inStream) throws Exception {
+		ByteArrayOutputStream outSteam = new ByteArrayOutputStream();
+		byte[] buffer = new byte[65536];
+		int len;
+		while ((len = inStream.read(buffer)) != -1) {
+			outSteam.write(buffer, 0, len);
+		}
+		outSteam.close();
+		inStream.close();
+		return outSteam.toByteArray();
+	}
 }

--- a/src/test/java/cn/nukkit/test/VarIntTest.java
+++ b/src/test/java/cn/nukkit/test/VarIntTest.java
@@ -1,0 +1,32 @@
+package cn.nukkit.test;
+
+import cn.nukkit.utils.VarInt;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * By lmlstarqaq http://snake1999.com/
+ * Creation time: 2017/7/5 23:22.
+ */
+@DisplayName("VarInt")
+class VarIntTest {
+
+	@DisplayName("ZigZag")
+	@Test
+	void testZigZag() {
+		assertAll(
+				() -> assertEquals(0x2468acf0, VarInt.encodeZigZag32(0x12345678)),
+				() -> assertEquals(0x2b826b1d, VarInt.encodeZigZag32(0xea3eca71)),
+				() -> assertEquals(0x12345678, VarInt.decodeZigZag32(0x2468acf0)),
+				() -> assertEquals(0xea3eca71, VarInt.decodeZigZag32(0x2b826b1d)),
+				() -> assertEquals(new BigInteger("2623536930346282224"), VarInt.encodeZigZag64(0x1234567812345678L)),
+				() -> assertEquals(new BigInteger("3135186066796324391"), VarInt.encodeZigZag64(0xea3eca710becececL)),
+				() -> assertEquals(BigInteger.valueOf(0x1234567812345678L), VarInt.decodeZigZag64(new BigInteger("2623536930346282224"))),
+				() -> assertEquals(BigInteger.valueOf(0xea3eca710becececL), VarInt.decodeZigZag64(new BigInteger("3135186066796324391")))
+		);
+	}
+}

--- a/src/test/java/cn/nukkit/test/VarIntTest.java
+++ b/src/test/java/cn/nukkit/test/VarIntTest.java
@@ -5,6 +5,7 @@ import cn.nukkit.utils.VarInt;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.*;
 import java.math.BigInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,20 +32,46 @@ class VarIntTest {
 		);
 	}
 
-	@DisplayName("Encoding and decoding")
+	@DisplayName("Writing")
 	@Test
-	void testCoding() {
+	void testWrite() throws IOException {
+		BinaryStream bs = new BinaryStream();
+		VarInt.writeUnsignedVarInt(bs, 237356812);
+		VarInt.writeVarInt(bs, 0xea3eca71);
+		VarInt.writeUnsignedVarLong(bs, 0x1234567812345678L);
+		VarInt.writeVarLong(bs, 0xea3eca710becececL);
+		assertAll(
+				() -> assertEquals(237356812, VarInt.readUnsignedVarInt(bs)),
+				() -> assertEquals(0xea3eca71, VarInt.readVarInt(bs)),
+				() -> assertEquals(0x1234567812345678L, VarInt.readUnsignedVarLong(bs)),
+				() -> assertEquals(0xea3eca710becececL, VarInt.readVarLong(bs))
+		);
+		ByteArrayOutputStream os = new ByteArrayOutputStream();
+		VarInt.writeUnsignedVarInt(os, 237356812);
+		VarInt.writeVarInt(os, 0xea3eca71);
+		VarInt.writeUnsignedVarLong(os, 0x1234567812345678L);
+		VarInt.writeVarLong(os, 0xea3eca710becececL);
+		ByteArrayInputStream is = new ByteArrayInputStream(os.toByteArray());
+		assertAll(
+				() -> assertEquals(237356812, VarInt.readUnsignedVarInt(is)),
+				() -> assertEquals(0xea3eca71, VarInt.readVarInt(is)),
+				() -> assertEquals(0x1234567812345678L, VarInt.readUnsignedVarLong(is)),
+				() -> assertEquals(0xea3eca710becececL, VarInt.readVarLong(is))
+		);
+	}
+
+	@DisplayName("Reading")
+	@Test
+	void testRead() {
 		assertAll(
 				() -> assertEquals(2412, VarInt.readUnsignedVarInt(wrapBinaryStream("EC123EC456"))),
 				() -> assertEquals(583868, VarInt.readUnsignedVarInt(wrapBinaryStream("BCD123EFA0"))),
 				() -> assertEquals(1206, VarInt.readVarInt(wrapBinaryStream("EC123EC456"))),
 				() -> assertEquals(291934, VarInt.readVarInt(wrapBinaryStream("BCD123EFA0"))),
-				() -> assertEquals("6015", VarInt.readUnsignedVarLong(wrapBinaryStream("FF2EC456EC789EC012EC")).toString()),
-				() -> assertEquals("3694", VarInt.readUnsignedVarLong(wrapBinaryStream("EE1CD34BCD56BCD78BCD")).toString()),
+				() -> assertEquals(6015, VarInt.readUnsignedVarLong(wrapBinaryStream("FF2EC456EC789EC012EC"))),
+				() -> assertEquals(3694, VarInt.readUnsignedVarLong(wrapBinaryStream("EE1CD34BCD56BCD78BCD"))),
 				() -> assertEquals(-3008, VarInt.readVarLong(wrapBinaryStream("FF2EC456EC789EC012EC"))),
 				() -> assertEquals(1847, VarInt.readVarLong(wrapBinaryStream("EE1CD34BCD56BCD78BCD")))
-
-
 		);
 	}
 

--- a/src/test/java/cn/nukkit/test/VarIntTest.java
+++ b/src/test/java/cn/nukkit/test/VarIntTest.java
@@ -1,5 +1,6 @@
 package cn.nukkit.test;
 
+import cn.nukkit.utils.BinaryStream;
 import cn.nukkit.utils.VarInt;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,10 +24,46 @@ class VarIntTest {
 				() -> assertEquals(0x2b826b1d, VarInt.encodeZigZag32(0xea3eca71)),
 				() -> assertEquals(0x12345678, VarInt.decodeZigZag32(0x2468acf0)),
 				() -> assertEquals(0xea3eca71, VarInt.decodeZigZag32(0x2b826b1d)),
-				() -> assertEquals(new BigInteger("2623536930346282224"), VarInt.encodeZigZag64(0x1234567812345678L)),
-				() -> assertEquals(new BigInteger("3135186066796324391"), VarInt.encodeZigZag64(0xea3eca710becececL)),
-				() -> assertEquals(BigInteger.valueOf(0x1234567812345678L), VarInt.decodeZigZag64(new BigInteger("2623536930346282224"))),
-				() -> assertEquals(BigInteger.valueOf(0xea3eca710becececL), VarInt.decodeZigZag64(new BigInteger("3135186066796324391")))
+				() -> assertEquals(2623536930346282224L, VarInt.encodeZigZag64(0x1234567812345678L)),
+				() -> assertEquals(3135186066796324391L, VarInt.encodeZigZag64(0xea3eca710becececL)),
+				() -> assertEquals(0x1234567812345678L, VarInt.decodeZigZag64(2623536930346282224L)),
+				() -> assertEquals(0xea3eca710becececL, VarInt.decodeZigZag64(3135186066796324391L))
 		);
+	}
+
+	@DisplayName("Encoding and decoding")
+	@Test
+	void testCoding() {
+		assertAll(
+				() -> assertEquals(2412, VarInt.readUnsignedVarInt(wrapBinaryStream("EC123EC456"))),
+				() -> assertEquals(583868, VarInt.readUnsignedVarInt(wrapBinaryStream("BCD123EFA0"))),
+				() -> assertEquals(1206, VarInt.readVarInt(wrapBinaryStream("EC123EC456"))),
+				() -> assertEquals(291934, VarInt.readVarInt(wrapBinaryStream("BCD123EFA0"))),
+				() -> assertEquals("6015", VarInt.readUnsignedVarLong(wrapBinaryStream("FF2EC456EC789EC012EC")).toString()),
+				() -> assertEquals("3694", VarInt.readUnsignedVarLong(wrapBinaryStream("EE1CD34BCD56BCD78BCD")).toString()),
+				() -> assertEquals(-3008, VarInt.readVarLong(wrapBinaryStream("FF2EC456EC789EC012EC"))),
+				() -> assertEquals(1847, VarInt.readVarLong(wrapBinaryStream("EE1CD34BCD56BCD78BCD")))
+
+
+		);
+	}
+
+	private static BinaryStream wrapBinaryStream(String hex) {
+		return new BinaryStream(hexStringToByte(hex));
+	}
+
+	private static byte[] hexStringToByte(String hex) {
+		int len = (hex.length() / 2);
+		byte[] result = new byte[len];
+		char[] aChar = hex.toCharArray();
+		for (int i = 0; i < len; i++) {
+			int pos = i * 2;
+			result[i] = (byte) (toByte(aChar[pos]) << 4 | toByte(aChar[pos + 1]));
+		}
+		return result;
+	}
+
+	private static byte toByte(char c) {
+		return (byte) "0123456789ABCDEF".indexOf(c);
 	}
 }


### PR DESCRIPTION
The purpose of this PR is to enhance the efficiency of VarInt under huge network I/O. Nukkit have uses BigInteger to store VarInt values, but created large amounts of instances of BigInteger , which consumes up almost all the heap memory - that is 2.47 GiB or nearly 500 MiB per second for tested server under 1Gbps network I/O and hundreds of players, where JVM have to do the GC almost every 5 seconds and cause 200 ms of pauses each to reduce memory usage. 
By using enhanced VarInt, no instances of BigInteger is created. Less memory is now used by Nukkit network engines :)

- [x] Unit testing using JUnit 5 and maven surefire
- [x] Convert AngleTest and ClientChainDataTest into JUnit testing
- [x] Test unit for VarInt
- [x] Enhance VarInt for huge network I/O requirements