### PR TITLE
Reduce memory usage, phase 2 (Zlib)

### DIFF
--- a/src/main/java/cn/nukkit/utils/Zlib.java
+++ b/src/main/java/cn/nukkit/utils/Zlib.java
@@ -4,25 +4,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Map;
-import java.util.Optional;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.zip.Deflater;
 import java.util.zip.InflaterInputStream;
 
 
 public abstract class Zlib {
-
-    private static final ThreadLocal<byte[]> buf = ThreadLocal.withInitial(() -> new byte[1024]);
-    private static final ThreadLocal<Deflater> def = ThreadLocal.withInitial(Deflater::new);
-
-    private static Deflater getDef(int level) {
-        def.get().setLevel(level);
-        return def.get();
-    }
-
+    
     public static byte[] deflate(byte[] data) throws Exception {
         return deflate(data, Deflater.DEFAULT_COMPRESSION);
     }
@@ -48,6 +35,16 @@ public abstract class Zlib {
 
     public static byte[] inflate(byte[] data, int maxSize) throws IOException {
         return inflate(new ByteArrayInputStream(data, 0, maxSize));
+    }
+
+    /* -=-=-=-=-=- Internal -=-=-=-=-=- Do NOT attempt to use in production -=-=-=-=-=- */
+
+    private static final ThreadLocal<byte[]> buf = ThreadLocal.withInitial(() -> new byte[1024]);
+    private static final ThreadLocal<Deflater> def = ThreadLocal.withInitial(Deflater::new);
+
+    private static Deflater getDef(int level) {
+        def.get().setLevel(level);
+        return def.get();
     }
 
     private static byte[] inflate(InputStream stream) throws IOException {

--- a/src/main/java/cn/nukkit/utils/Zlib.java
+++ b/src/main/java/cn/nukkit/utils/Zlib.java
@@ -4,52 +4,42 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.Deflater;
 import java.util.zip.InflaterInputStream;
 
 
 public abstract class Zlib {
 
+    private static final ThreadLocal<byte[]> buf = ThreadLocal.withInitial(() -> new byte[1024]);
+    private static final ThreadLocal<Deflater> def = ThreadLocal.withInitial(Deflater::new);
+
+    private static Deflater getDef(int level) {
+        def.get().setLevel(level);
+        return def.get();
+    }
+
     public static byte[] deflate(byte[] data) throws Exception {
         return deflate(data, Deflater.DEFAULT_COMPRESSION);
     }
 
     public static byte[] deflate(byte[] data, int level) throws Exception {
-        Deflater deflater = new Deflater(level);
+        Deflater deflater = getDef(level);
+        if(deflater == null) throw new IllegalArgumentException("No deflate for level "+level+" !");
         deflater.reset();
         deflater.setInput(data);
         deflater.finish();
         ByteArrayOutputStream bos = new ByteArrayOutputStream(data.length);
-        byte[] buf = new byte[1024];
-        try {
-            while (!deflater.finished()) {
-                int i = deflater.deflate(buf);
-                bos.write(buf, 0, i);
-            }
-        } finally {
-            deflater.end();
+        while (!deflater.finished()) {
+            int i = deflater.deflate(buf.get());
+            bos.write(buf.get(), 0, i);
         }
+        //Deflater::end is called the time when the process exits.
         return bos.toByteArray();
-    }
-
-    public static byte[] inflate(InputStream stream) throws IOException {
-        InflaterInputStream inputStream = new InflaterInputStream(stream);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        byte[] buffer = new byte[1024];
-        int length;
-
-        try {
-            while ((length = inputStream.read(buffer)) != -1) {
-                outputStream.write(buffer, 0, length);
-            }
-        } finally {
-            buffer = outputStream.toByteArray();
-            outputStream.flush();
-            outputStream.close();
-            inputStream.close();
-        }
-
-        return buffer;
     }
 
     public static byte[] inflate(byte[] data) throws IOException {
@@ -59,6 +49,26 @@ public abstract class Zlib {
     public static byte[] inflate(byte[] data, int maxSize) throws IOException {
         return inflate(new ByteArrayInputStream(data, 0, maxSize));
     }
+
+    private static byte[] inflate(InputStream stream) throws IOException {
+        InflaterInputStream inputStream = new InflaterInputStream(stream);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        int length;
+
+        try {
+            while ((length = inputStream.read(buf.get())) != -1) {
+                outputStream.write(buf.get(), 0, length);
+            }
+        } finally {
+            buf.set(outputStream.toByteArray());
+            outputStream.flush();
+            outputStream.close();
+            inputStream.close();
+        }
+
+        return buf.get();
+    }
+
 
 }
 

--- a/src/test/java/cn/nukkit/test/VarIntTest.java
+++ b/src/test/java/cn/nukkit/test/VarIntTest.java
@@ -5,10 +5,12 @@ import cn.nukkit.utils.VarInt;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
-import java.math.BigInteger;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * By lmlstarqaq http://snake1999.com/

--- a/src/test/java/cn/nukkit/test/ZlibTest.java
+++ b/src/test/java/cn/nukkit/test/ZlibTest.java
@@ -1,0 +1,23 @@
+package cn.nukkit.test;
+
+import cn.nukkit.utils.Zlib;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("Zlib")
+class ZlibTest {
+
+    @DisplayName("Inflate and Deflate")
+    @Test
+    void testAll() throws Exception {
+        byte[] in = "lmlstarqaq".getBytes();
+        byte[] compressed = Zlib.deflate(in);
+        byte[] out = Zlib.inflate(compressed);
+        assertTrue(Arrays.equals(in, out));
+    }
+
+}


### PR DESCRIPTION
We have reduced memory usage by enhanced VarInt in parse 1 (https://github.com/Nukkit/Nukkit/pull/1776).
Zlib is eating more and more memory as well. That is caused by creating too much instances by the deflater and inflater. Doing enhancements :)
Also see https://github.com/Nukkit/Nukkit/issues/1789.

Tests have done for commit on "Reduce byte array creation". In each test round, one player joins the server, stay for 30 seconds, then run to the horizon for 30 seconds, then quit the game. *Controlled group using software before this PR, experimental group using software after "Small improvement for Zlib"*. After 5 test round each group, *450 MiB (max VM submit) and 310 MiB (max VM consume) of memory is used by controlled group*, while *300 MiB (max VM submit) and 240 MiB (max VM consume) is for experimental group*. **About one quarter of memory is saved**. 

Further enhancement will be applied using Netty-provided ByteBuf.

- [x] Reduce byte array creation
- [x] Test class for Zlib
- [ ] Replace byte array and its streams to ByteBuf provided by Netty