### PR TITLE
Fix for Issue #1795: Non-Arrow projectiles shouldn't cause damage

### DIFF
--- a/src/main/java/cn/nukkit/entity/projectile/EntityArrow.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityArrow.java
@@ -91,7 +91,8 @@ public class EntityArrow extends EntityProjectile {
         return base;
     }
 
-    private double getBaseDamage() {
+    @Override
+    protected double getBaseDamage() {
         return 2;
     }
 

--- a/src/main/java/cn/nukkit/entity/projectile/EntityArrow.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityArrow.java
@@ -91,6 +91,10 @@ public class EntityArrow extends EntityProjectile {
         return base;
     }
 
+    private double getBaseDamage() {
+        return 2;
+    }
+
     @Override
     public boolean onUpdate(int currentTick) {
         if (this.closed) {

--- a/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
@@ -23,7 +23,11 @@ public abstract class EntityProjectile extends Entity {
     public Entity shootingEntity = null;
 
     protected double getDamage() {
-        return namedTag.contains("damage") ? namedTag.getDouble("damage") : 2;
+        return namedTag.contains("damage") ? namedTag.getDouble("damage") : getBaseDamage();
+    }
+
+    private double getBaseDamage() {
+        return 0;
     }
 
     public boolean hadCollision = false;

--- a/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
@@ -26,7 +26,7 @@ public abstract class EntityProjectile extends Entity {
         return namedTag.contains("damage") ? namedTag.getDouble("damage") : getBaseDamage();
     }
 
-    private double getBaseDamage() {
+    protected double getBaseDamage() {
         return 0;
     }
 


### PR DESCRIPTION
This change fixes Issue #1795 

It changes the damage logic to allow base damage to be overridden on a per-projectile basis, defaulting to zero (no damage).  Only arrow overrides this, so only arrows cause damage.

I reused the old projectile damage amount of 2, now just for arrows.

I have tested by shooting arrows and snowballs straight up into the air in survival mode.  Arrows still cause damage when they fall, but snowballs no longer do.

Let me know how it looks, this is my first Nukkit commit so I could easily have missed something.