### PR TITLE
Fixed duplicate dropped item

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1282,11 +1282,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 pk.target = entity.getId();
                 Server.broadcastPacket(entity.getViewers().values(), pk);
 
-                pk = new TakeItemEntityPacket();
-                pk.entityId = this.id;
-                pk.target = entity.getId();
-                this.dataPacket(pk);
-
                 this.inventory.addItem(item.clone());
                 entity.kill();
             } else if (entity instanceof EntityItem) {
@@ -1326,11 +1321,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         pk.entityId = this.getId();
                         pk.target = entity.getId();
                         Server.broadcastPacket(entity.getViewers().values(), pk);
-
-                        pk = new TakeItemEntityPacket();
-                        pk.entityId = this.id;
-                        pk.target = entity.getId();
-                        this.dataPacket(pk);
 
                         this.inventory.addItem(item.clone());
                         entity.kill();


### PR DESCRIPTION
It's useless to send 2 times the TakeItemEntityPacket, because it is already sending it to every viewers of the entity which is the dropped item.