### PR TITLE
cn.nukkit.command.register can't change the commandMap!

### DIFF
--- a/src/main/java/cn/nukkit/command/Command.java
+++ b/src/main/java/cn/nukkit/command/Command.java
@@ -207,7 +207,7 @@ public abstract class Command {
     }
 
     public boolean allowChangesFrom(CommandMap commandMap) {
-        return commandMap == null || commandMap.equals(this.commandMap);
+        return commandMap != null && !commandMap.equals(this.commandMap);
     }
 
     public boolean isRegistered() {


### PR DESCRIPTION
The function allowChangesFrom(CommandMap commandMap) should return true to change the this.commandMap when commandMap isn't null and different from the old commandMap