### PR TITLE
Fixed PlayerInventory#setArmorContents

### DIFF
--- a/src/main/java/cn/nukkit/inventory/PlayerInventory.java
+++ b/src/main/java/cn/nukkit/inventory/PlayerInventory.java
@@ -344,7 +344,7 @@ public class PlayerInventory extends BaseInventory {
             if (items[i].getId() == Item.AIR) {
                 this.clear(this.getSize() + i);
             } else {
-                this.setItem(this.getSize() + 1, items[i]);
+                this.setItem(this.getSize() + i, items[i]);
             }
         }
     }


### PR DESCRIPTION
PlayerInventory#setArmorContents can only change chestplate because of a bug in `for (int i = 0; i < 4; ++i) `:
`this.setItem(this.getSize() + 1, items[i]);`
it should be written as:
`this.setItem(this.getSize() + i, items[i]);`