### PR TITLE
Fix for #1861

### DIFF
--- a/src/main/java/cn/nukkit/level/Explosion.java
+++ b/src/main/java/cn/nukkit/level/Explosion.java
@@ -90,8 +90,8 @@ public class Explosion {
                                 break;
                             }
                             Block block = this.level.getBlock(vBlock);
-
-                            if (block.getId() != 0) {
+                            int id = block.getId();
+                            if (id != 0 && id != Block.OBSIDIAN && id != Block.BEDROCK) {
                                 blastForce -= (block.getResistance() / 5 + 0.3d) * this.stepLen;
                                 if (blastForce > 0) {
                                     if (!this.affectedBlocks.contains(block)) {


### PR DESCRIPTION
Small explanation, I reduce the call to Block.getId(); in the way to store it as an int don't really know if this affects much probably not but I like it in the way and why do I don't check the explosion resistance of the block in this fix? Because it's obvious for me these two blocks are not destroyable thats why I block in that way further calculations, which is imo performance improvement. Sorry if formatting isn't in the way it should be. (@SupremeMortal , @NycuRO)

Edit: Oops title does not link to issue so here #1861.