### PR TITLE
Removed redundant message

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -1380,12 +1380,14 @@ public class Server {
         String path = this.getDataPath() + "players/";
         File file = new File(path + name + ".dat");
 
-        if (this.shouldSavePlayerData() && file.exists()) {
-            try {
-                return NBTIO.readCompressed(new FileInputStream(file));
-            } catch (Exception e) {
-                file.renameTo(new File(path + name + ".dat.bak"));
-                this.logger.notice(this.getLanguage().translateString("nukkit.data.playerCorrupted", name));
+        if (this.shouldSavePlayerData()) {
+            if (file.exists()) {
+                try {
+                    return NBTIO.readCompressed(new FileInputStream(file));
+                } catch (Exception e) {
+                    file.renameTo(new File(path + name + ".dat.bak"));
+                    this.logger.notice(this.getLanguage().translateString("nukkit.data.playerCorrupted", name));
+                }
             }
         } else {
             this.logger.notice(this.getLanguage().translateString("nukkit.data.playerNotFound", name));


### PR DESCRIPTION
Removed the "Player data not found for "Steve", creating new profile" when save-player-data is set to false.