### PR TITLE
Fix block breaking

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1806,8 +1806,7 @@ public class Level implements ChunkManager, Metadatable {
                 breakTime *= 1 - (0.3 * eff.getLevel());
             }
 
-            //breakTime -= 0.1;
-            //TODO: Check if it's necessary to minus breakTime with 0.1.
+            breakTime -= 0.1;
 
             BlockBreakEvent ev = new BlockBreakEvent(player, target, item, player.isCreative(),
                     (player.lastBreak + breakTime * 1000) > System.currentTimeMillis());


### PR DESCRIPTION
This is needed, otherwise Nukkit will think the player is using fast break multiple times and it will not break the block.