### PR TITLE
Fix issue when attempt to register block entity by plugin

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2367,14 +2367,18 @@ public class Level implements ChunkManager, Metadatable {
 
             for (Entity entity : oldEntities.values()) {
                 chunk.addEntity(entity);
-                oldChunk.removeEntity(entity);
-                entity.chunk = chunk;
+                if (oldChunk != null) {
+                    oldChunk.removeEntity(entity);
+                    entity.chunk = chunk;
+                }
             }
 
             for (BlockEntity blockEntity : oldBlockEntities.values()) {
                 chunk.addBlockEntity(blockEntity);
-                oldChunk.removeBlockEntity(blockEntity);
-                blockEntity.chunk = chunk;
+                if (oldChunk != null) {
+                    oldChunk.removeBlockEntity(blockEntity);
+                    blockEntity.chunk = chunk;
+                }
             }
 
             this.provider.setChunk(chunkX, chunkZ, chunk);


### PR DESCRIPTION
A leak in setChunk resulting this thing to came out:
```
17:00:17 [CRITICAL] Exception while async task 0 invoking onCompletion
java.util.ConcurrentModificationException
at java.util.HashMap$HashIterator.nextNode(HashMap.java:1437)
at java.util.HashMap$ValueIterator.next(HashMap.java:1466)
at cn.nukkit.level.Level.setChunk(Level.java:2376)
at cn.nukkit.level.Level.generateChunkCallback(Level.java:2321)
at cn.nukkit.level.generator.task.PopulationTask.onCompletion(PopulationTask.java:164)
at cn.nukkit.scheduler.AsyncTask.collectTask(AsyncTask.java:83)
at cn.nukkit.scheduler.ServerScheduler.mainThreadHeartbeat(ServerScheduler.java:301)
at cn.nukkit.Server.tick(Server.java:1004)
at cn.nukkit.Server.tickProcessor(Server.java:794)
at cn.nukkit.Server.start(Server.java:773)
at cn.nukkit.Server.(Server.java:464)
at cn.nukkit.Nukkit.main(Nukkit.java:68)
```
This had been tested by following code:
```java
FullChunk chunk = level.getChunk((int) pos.x >> 4, (int) pos.z >> 4);
BlockEntity.createBlockEntity(BlockEntity.CHEST, chunk, nbt);
```
You may see the diffrent.
### Step to reproduce this problem:
1. Put a chest and spawn them by plugin
2. Spawn the player nearby the block
3. You may see that chest wont spawn