### PR TITLE
Add epoll support for better scalability on Linux operating systems.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,16 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <artifactId>netty-handler</artifactId>
             <version>4.1.6.Final</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>4.1.6.Final</version>
+            <scope>compile</scope>
+            <classifier>linux-x86_64</classifier>
         </dependency>
         <dependency>
             <groupId>com.github.dblock</groupId>


### PR DESCRIPTION
Also removed excess `netty-all` dependency shaving over 1MB off the compiled jar.