### PR TITLE
fix short read bug

### DIFF
--- a/src/main/java/cn/nukkit/utils/Binary.java
+++ b/src/main/java/cn/nukkit/utils/Binary.java
@@ -222,7 +222,7 @@ public class Binary {
     }
 
     public static int readLShort(byte[] bytes) {
-        return (bytes[1] & 0xFF << 8) + (bytes[0] & 0xFF);
+        return ((bytes[1] & 0xFF) << 8) + (bytes[0] & 0xFF);
     }
 
     public static short readSignedLShort(byte[] bytes) {


### PR DESCRIPTION
this bug may cause server not able to read long nbt tag,
in java << has higher propriety than &